### PR TITLE
Tradução de artigos

### DIFF
--- a/todo/detecting-double-spending.html
+++ b/todo/detecting-double-spending.html
@@ -4,147 +4,147 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
 	<div class="page-header">
   	<h1 class="text-center">
-  		Detecting Double Spending <br><small>Hal Finney</small>
+  		Detectando Gastos Duplicados <br><small>Hal Finney</small>
   	</h1>
   	<h4 class="text-center">
-  		October 15, 1993<br>
-      (Revised March 13, 1996)
+  		15 de outubro de 1993 <br>
+      (revisado em 13 de março de 1996)
   	</h4>
   </div>
 	<p>
-		Here is an attempt to describe Chaum's digital cash from his paper, Untraceable Electronic Cash, by Chaum, Fiat, and Naor, from the Crypto 88 proceedings. This cash has the property that the user of the cash can remain anonymous so long as she does not spend it more than once, but if she does double-spend then her identity is revealed.
+		Aqui está uma tentativa de descrever o dinheiro digital de Chaum a partir de seu trabalho, Untraceable Electronic Cash, de Chaum, Fiat e Naor, do processo Crypto 88. Esse dinheiro tem a propriedade de que o usuário do dinheiro pode permanecer anônimo, desde que não o gaste mais de uma vez, mas se ela gastar duas vezes, sua identidade será revelada.
 	</p>
 
   <p>
-    This is how it works in general terms: Alice opens an account with a bank non-anonymously. She shows ID so that the bank knows who she is; both she and the bank know her account number. When she withdraws cash, she goes to the bank or contacts them electronically and presents some proof of who she is and what her account number is, and the bank gives her some digital cash. The digital cash is an information pattern, perhaps stored in a computer file on a smart card or magnetic disk. Later, she spends the digital cash by sending or giving it to Bob, a merchant. Bob can check and verify that the cash must have come from the bank. He accepts the cash if it is valid, giving Alice the merchandise. Later, he sends the cash to the bank to be added to his own account.
+    É assim que funciona em termos gerais: Alice abre uma conta com um banco de forma não anônima. Ela mostra a identidade para que o banco saiba quem ela é; tanto ela como o banco sabem o número da sua conta. Quando ela sacar dinheiro, ela vai ao banco ou entra em contato com eles eletronicamente e apresenta uma prova de quem ela é e qual é o seu número de conta, e o banco lhe dá algum dinheiro digital. O dinheiro digital é um padrão de informação, talvez armazenado em um arquivo de computador em um cartão inteligente ou disco magnético. Mais tarde, ela gasta o dinheiro digital enviando ou dando para Bob, um comerciante. Bob pode verificar e verificar se o dinheiro deve ter vindo do banco. Ele aceita o dinheiro se for válido, dando a Alice a mercadoria. Mais tarde, ele envia o dinheiro para o banco para ser adicionado à sua própria conta.
   </p>
 
   <p>
-    Note that this much could basically be done with a simple RSA signature. The bank could give Alice a statement saying, "this is worth $1", signed by the bank's secret key. Bob could verify that the statement was in fact signed by the bank, and know therefore that no one else than the bank could have created that statement. He accepts it and sends it to the bank, which honors it since it recognizes its own signature.
+    Note que isso basicamente poderia ser feito com uma simples assinatura RSA. O banco poderia dar a Alice uma declaração dizendo: "vale 1 dólar", assinada pela chave secreta do banco. Bob poderia verificar se a declaração estava de fato assinada pelo banco e, portanto, saber que ninguém mais do que o banco poderia ter criado essa declaração. Ele aceita e envia para o banco, que o homenageia porque reconhece sua própria assinatura.
   </p>
 
   <p>
-    One problem with this trivial money is that double-spending can not be detected or prevented since all the cash looks alike. This can be remedied by having the cash include a unique serial number. Now when Bob goes to accept the cash from Alice, he can call the bank and say, has anyone else deposited serial number 123456? If not, he accepts the cash and deposits it. This is called on-line electronic money; the merchant must check with the bank for each transaction.
+    Um problema com esse dinheiro trivial é que o gasto duplo não pode ser detectado ou evitado, já que todo o dinheiro parece igual. Isso pode ser remediado com o dinheiro incluir um número de série exclusivo. Agora, quando Bob vai aceitar o dinheiro de Alice, ele pode ligar para o banco e dizer: alguém mais depositou o número de série 123456? Se não, ele aceita o dinheiro e deposita-o. Isso é chamado de dinheiro eletrônico on-line; o comerciante deve verificar com o banco para cada transação.
   </p>
 
   <p>
-    This improved simple system does not deserve to be called cash, though, because it lacks the distinguishing characteristic of digital cash: it is not anonymous. When the bank sees money with serial number 123456 being deposited, the bank recognizes that this was the same bill that Alice withdrew. The bank can therefore deduce that Alice spent the money at Bob's, and from this kind of information a dossier could be built up with all kinds of privacy-destroying information about her.
+    No entanto, esse sistema simples melhorado não merece ser chamado de caixa, porque não possui a característica distintiva do dinheiro digital: ele não é anônimo. Quando o banco recebe dinheiro com o número de série 123456 que está sendo depositado, o banco reconhece que essa foi a mesma fatura que Alice retirou. O banco pode, portanto, deduzir que Alice gastou o dinheiro na casa de Bob e, a partir desse tipo de informação, um dossiê poderia ser construído com todos os tipos de informações destruidoras de privacidade sobre ela.
   </p>
 
   <p>
-    To allow anonymity, we have to get into the mathematics. What we want is for Alice and the bank collectively to create an RSA signature from the bank that could not be forged, but one which the bank will not recognize as coming from Alice. This is the first thing Chaum's paper discusses.
+    Para permitir o anonimato, precisamos entrar na matemática. O que queremos é que Alice e o banco coletivamente criem uma assinatura RSA do banco que não pode ser falsificada, mas que o banco não reconhecerá como proveniente de Alice. Esta é a primeira coisa que o artigo de Chaum discute.
   </p>
 
   <p>
-    The money in this system is of the form (x, f(x)^(1/3)) mod n, where n is the bank's public modulus. f() (and, below, g()) is a one-way function, one which can be calculated easily but for which it is infeasible to calculate the inverse. It should also be infeasible to come up with two different y,z such that f(y) = f(z). Today there are several suitable choices for one-way functions, the most common being the MD5 algorithm from RSA, and the US government's Secure Hash Algorithm (SHA).
+    O dinheiro neste sistema é da forma (x, f (x) ^ (1/3)) mod n, onde n é o módulo público do banco. f () (e, abaixo, g ()) é uma função unidirecional, que pode ser calculada facilmente, mas para a qual é inviável calcular o inverso. Também deve ser inviável encontrar dois y diferentes, z tais que f (y) = f (z). Atualmente, existem várias opções adequadas para funções unidirecionais, sendo as mais comuns o algoritmo MD5 da RSA e o Secure Hash Algorithm (SHA) do governo dos EUA.
   </p>
 
   <p>
-    The reason the expression above would be accepted as cash is two-fold. First, only the bank can calculate anything ^ (1/3) mod n. This is basically the RSA signing operation for the exponent of 3. Nobody else can find cube roots. The reason f(x) is used is this. Suppose we proposed that (x, x^(1/3)) should be the cash, for some random x, reasoning that only the bank could find the cube root of x. Can you see how to forge cash like this? (Take a few moments and try to see how you could construct a pair like this even if you can't take cube roots.)
+    A razão pela qual a expressão acima seria aceita como dinheiro é dupla. Primeiro, apenas o banco pode calcular qualquer coisa ^ (1/3) mod n. Esta é basicamente a operação de assinatura RSA para o expoente de 3. Ninguém mais pode encontrar raízes cúbicas. A razão f (x) é usada é isso. Suponha que nós propusemos que (x, x ^ (1/3)) deveria ser o dinheiro, para algum x aleatório, raciocinando que somente o banco poderia encontrar a raiz cúbica de x. Você pode ver como forjar dinheiro assim? (Dedique alguns instantes e tente ver como você pode construir um par como este, mesmo que você não consiga criar raízes cúbicas.)
   </p>
 
   <p>
-    The answer is that it is easy to forge this by first choosing a random y, and exhibiting the pair (y^3, y). Now we have a number and then its cube root. Yet we didn't have to take any cube roots to find it. That's why this kind of money would be no good.
+    A resposta é que é fácil forjar isso escolhendo primeiro um y aleatório e exibindo o par (y ^ 3, y). Agora temos um número e depois sua raiz cúbica. No entanto, não precisamos ter raízes cúbicas para encontrá-lo. É por isso que esse tipo de dinheiro não seria bom.
+   </p>
+
+  <p>
+    O sistema de Chaum evita isso pegando a raiz cúbica de uma função unidirecional de x. Para forjar sem ter uma raiz cúbica, você teria que produzir (finv (y ^ 3), y), que corresponderia ao padrão acima, mas não é possível inverter a função unidirecional como essa. Portanto, apenas o banco pode criar dinheiro da forma apropriada. Isso pode ser pensado como a forma formal e matemática do meu "dinheiro" informal, acima do qual havia uma nota assinada digitalmente com um número de série. Aqui, x é o número de série e é assinado digitalmente desta maneira especial. Nada mais é necessário.
   </p>
 
   <p>
-    Chaum's system avoids this by taking the cube root of a one-way function of x. To forge it without taking a cube root you'd have to produce (finv(y^3), y), which would match the above pattern, but you can't invert the one-way function like that. So only the bank can create money of the proper form. This can be thought of as the formal, mathematical form of my informal "money" above which was a digitally signed note with a serial number. Here, x is the serial number, and it's digitally signed in this special way. Nothing more is needed.
+    A coisa boa sobre esse dinheiro é que ele permite cegar, um método de fazer com que o banco assine o valor sem saber que valor ele está assinando. Funciona assim. Alice escolhe x, que será o x no dinheiro. Ela calcula f (x), mas em vez de enviá-la ao banco para ser assinada (aumentada para 1/3 de poder) ela escolhe primeiro um número aleatório r e envia f (x) * r ^ 3 para o banco. O banco leva esse número para 1/3 da potência, obtendo r * f (x) ^ (1/3). Lembre-se, porém, que o banco não vê r ou f (x) separadamente, mas apenas seu produto. Não sabe o que r ou f (x) é. Eles poderiam ser qualquer coisa, na verdade.
   </p>
 
   <p>
-    The nice thing about this money is that it allows for blinding, a method of having the bank sign the value without knowing what value it is signing. It works like this. Alice chooses x, which will be the x in the cash. She calculates f(x), but instead of sending it to the bank to be signed (raised to the 1/3 power) she first chooses a random number r, and sends f(x)*r^3 to the bank. The bank takes this number to the 1/3 power, getting r * f(x)^(1/3). Remember, though, that the bank doesn't see r or f(x) separately, but just their product. It doesn't know what r or f(x) is. They could each be anything, actually.
+    O banco envia este r * f (x) ^ (1/3) de volta para Alice, e ela divide por r, que ela sabe. Isso dá a ela f (x) ^ (1/3), e ela coloca isso junto com x para obter seu dinheiro digital: (x, f (x) ^ (1/3)). Ela tem um dinheiro que só poderia ter sido assinado pelo banco, mas o banco não o reconhece quando é depositado.
   </p>
 
   <p>
-    The bank sends this r * f(x)^(1/3) back to Alice, and she divides it by r, which she knows. This gives her f(x)^(1/3), and she puts that together with x to get her digital cash: (x, f(x)^(1/3)). She has a piece of money which could only have been signed by the bank, yet the bank won't recognize it when it is deposited.
+    Outras coisas, não matemáticas, acontecem quando esta retirada continua. Alice deve provar sua identidade ao banco, como mencionado acima. E o banco debitará sua conta pelo valor do dinheiro. Neste sistema, assumimos por simplicidade que todo o dinheiro tem o mesmo valor. Em um sistema real, diferentes valores podem ser codificados por expoentes diferentes de 3.
   </p>
 
   <p>
-    Other, non-mathematical, things take place as this withdrawal goes on. Alice must prove her identity to the bank, as mentioned above. And the bank will debit her account by the value of the cash. In this system, we are assuming for simplicity that all cash has the same value. In a real system, different values might be encoded by different exponents than 3.
+    Quando Alice deposita o dinheiro, Bob deve ligar para o banco para se certificar de que não foi depositado antes, sendo este um sistema "on-line". Embora o banco não reconheça x (nunca se ouve falar dele) ele se lembrará de todos os x's que foram depositados e assim poderá alertar Bob se o dinheiro tiver sido gasto anteriormente. Tanto Bob quanto o banco podem verificar a assinatura digital sobre o dinheiro e, assim, honrá-lo.
   </p>
 
   <p>
-    When Alice deposits the money, Bob must call the bank to make sure that it hasn't been deposited before, this being an "on-line" system. Although the bank won't recognize x (it's never heard of it) it will remember all the x's which have been deposited and so can alert Bob if the money has been spent before. Both Bob and the bank can verify the digital signature on the money and so will honor it.
+    Todo o material acima ocupa menos de uma página do artigo de nove páginas de Chaum. Para Chaum, isso é trivial. Agora chegamos à parte interessante. Agora vamos ver o esquema que permite que os gastadores de casal percam seu anonimato. Isso permitirá dinheiro eletrônico "off-line"; Bob não precisará mais verificar com o banco se o dinheiro já foi gasto. Ele aceita de Alice sabendo que, se ela trapaceia, o banco vai honrar o dinheiro e processar Alice para compensar a perda.
   </p>
 
   <p>
-    All the material above takes up less than one page of Chaum's nine-page paper. For Chaum, this much is trivial. Now we get to the interesting part. Now we will see the scheme that allows double-spenders to lose their anonymity. This will allow for "off-line" electronic cash; Bob will no longer have to check with the bank to see if the money has already been spent. He accepts it from Alice knowing that if she does cheat, the bank will honor the cash and sue Alice to make up the loss.
+    (Para tornar esta explicação mais fácil de seguir, descreverei uma versão ligeiramente simplificada do dinheiro off-line de Chaum. A versão que eu descrevo requer o uso de uma função unidirecional não-invertível como na f () usada acima. não requer uma suposição tão forte e fornece uma rastreabilidade "incondicional" mesmo se a função unidirecional for quebrada.)
   </p>
 
   <p>
-    (To make this explanation easier to follow, I will describe a slightly simplified version of Chaum's off-line cash. The version I describe requires the use of a non-invertable one-way function as in the f() used above. Chaum's version does not require as strong an assumption and provides "unconditional" untraceability even if the one-way function is broken.)
+    Vamos começar com a forma do dinheiro em si. É o produto dos números k / 2, onde k é um "parâmetro de segurança" que afeta a chance de sucesso de um trapaceiro. Cada número é da forma g (xi, yi) ^ (1/3), onde g é uma função unidirecional de dois argumentos semelhante à f acima. (O "xi", "yi", "ai", etc. aqui são valores separados para cada i de 0 ak / 2.)
   </p>
 
   <p>
-    Let's start with the form of the cash itself. It is the product of k/2 numbers, where k is a "security parameter" that affects the chance of a cheater succeeding. Each number is of the form g(xi,yi)^(1/3), where g is a two-argument one-way function similar to the f above. (The "xi", "yi", "ai", etc. here are separate values for each i from 0 to k/2.)
+    xi e yi são assim: xi = f (ai), onde ai é um número aleatório, e f é outra função unidirecional. yi é meio complicado. É f (ai xor <info>), onde <info>, a chave para toda essa operação, está identificando informações sobre a conta de Alice! É o número da sua conta concatenado com um número de série para o dinheiro.
   </p>
 
   <p>
-    xi and yi are like this: xi = f(ai), where ai is a random number, and f is another one-way function. yi is kind of complicated. It is f(ai xor &lt;info&gt;), where &lt;info&gt;, the key to this whole operation, is identifying information about Alice's account! It is her account number concatenated with a serial number for the cash.
+    Agora, por que passar por tudo isso? Aqui está o porquê. Se você pudesse descobrir ai e (ai xor <info>), para algum eu, você saberia a identidade de Alice. (Xor'ing eles produziriam <info>.) Quando Alice double-gasta, ambos ai e ai xor <info> serão revelados.
   </p>
 
   <p>
-    Now, why go through all this? Here's why. If you could find out both ai and (ai xor &lt;info&gt;), for some i, you would know Alice's identity. (Xor'ing them would produce &lt;info&gt;.) When Alice double-spends, both ai and ai xor &lt;info&gt;will be revealed.
+    O que acontece quando Alice gasta a moeda é isso. Para cada i de 0 a k / 2, Bob escolhe 0 ou 1 aleatoriamente. Se ele escolhe 1, ele é informado de ai e yi. Se ele escolher 0, ele será informado (ai xor <info>) e xi. Isso permitirá que ele verifique a assinatura do dinheiro, conforme descrito em mais detalhes abaixo.
   </p>
 
   <p>
-    What happens when Alice spends the coin is this. For each i from 0 to k/2 Bob chooses 0 or 1 at random. If he chooses 1 he gets told ai and yi. If he chooses 0 he gets told (ai xor &lt;info&gt;) and xi. This will let him check the signature on the money, as described in more detail below.
+    Note que quando Bob receber essa informação, ele saberá um monte de ai's, e ele saberá um monte de (ai xor <info>), mas eles são para i's diferentes. Ele não sabe ai e (ai xor <info>) para qualquer um i. Então ele não pode quebrar o anonimato de Alice.
   </p>
 
   <p>
-    Notice that when Bob gets this information, he'll know a bunch of ai's, and he'll know a bunch of (ai xor &lt;info&gt;)'s, but they are for different i's. He doesn't know both ai and (ai xor &lt;info&gt;) for any one i. So he can't break Alice's anonymity.
+    Quando Bob deposita o dinheiro no banco, ele repassa as informações que recebeu de Alice sobre o ai e tal.
   </p>
 
   <p>
-    When Bob deposits the money at the bank, he passes along the information he got from Alice regarding the ai's and such.
+    Agora, suponha que Alice trapaceie. Ela gasta o dinheiro de novo em algum outro lugar, no Charlie's. Charlie passa pelo mesmo procedimento que Bob, escolhendo 0 ou 1 aleatoriamente para cada valor de i. Aqui está o truque. Como ele está escolhendo aleatoriamente, seria muito improvável que ele escolhesse exatamente os mesmos 0s e 1s que Bob escolheu. (Aqui é onde o tamanho de k importa - tornando-se maior, torna menos provável que Charlie e Bob escolham o mesmo padrão de 0 e 1. Mas faz com que os cálculos demorem mais tempo.) Isso significa que para um ou mais valores de i, Charlie provavelmente escolherá um 0 onde Bob escolheu um 1, ou vice-versa.
   </p>
 
   <p>
-    Now, suppose Alice cheats. She spends the money again somewhere else, at Charlie's. Charlie goes through the same procedure as Bob, choosing 0 or 1 at random for each value of i. Here is the catch. Since he is choosing at random, it would be very unlikely that he will choose exactly the same 0's and 1's that Bob chose. (Here is where the size of k matters &ndash; making it bigger makes it less likely that Charlie and Bob will choose the same pattern of 0's and 1's. But it makes the calculations take longer.) That means for one or more values of i, Charlie will probably choose a 0 where Bob chose a 1, or vice versa.
+    Por causa disso, se o Bob tiver um ai para esse i, o Charlie irá obter ai xor <info>. Ou se Bob tiver ai xor <info>, Charlie vai ter ai. De qualquer forma, quando Charlie envia seu registro dessas informações para o banco, o banco coloca as informações de Bob e Charlie juntas e obtém os dois ai e ai xor <info>. Xor'ing estes juntos revela <info>, e Alice é pego! Essa é a ideia principal.
   </p>
 
   <p>
-    Because of this, if Bob got ai for that i, Charlie will get ai xor &lt;info&gt;. Or if Bob got ai xor &lt;info&gt;, Charlie will get ai. Either way, when Charlie sends his record of this information to the bank, the bank will put Bob's and Charlie's information together and get both ai and ai xor &lt;info&gt;. Xor'ing these together reveals &lt;info&gt;, and Alice is caught! This is the main idea.
+    (Chaum sugere não apenas depender da chance aleatória para garantir que Bob e Charlie usem conjuntos diferentes de 1 e 0. Pelo menos alguns dos bits podem ser atribuídos a Bob e Charlie pelo banco de tal forma que todos obtenham um número diferente. Desta forma, seria garantido que Bob e Charlie escolheriam valores opostos para alguns i.)
   </p>
 
   <p>
-    (Chaum suggests not just relying on random chance to make sure Bob and Charlie use different sets of 1's and 0's. At least some of the bits might be assigned to Bob and Charlie by the bank in such a way that everybody gets a different number. This way it would be guaranteed that Bob and Charlie would choose opposite values for some i.)
+    A razão para o dinheiro ter a forma que ele faz é para que Bob possa verificar se ele está assinado pelo banco. Para cada valor de i, Alice precisa fornecer informações suficientes para calcular xi e yi. Se Bob escolher um 1, ela dá a ele ai e yi. Dado ai Bob pode calcular xi (= f (ai)), e com isso e yi ele pode calcular g (xi, yi). Se Bob escolher um 0, ela lhe dará (ai xor <info>), como descrito anteriormente, e também xi. Dado (ai xor <info>), Bob calcula yi (= f (ai xor <info>)), e com isso e xi ele pode calcular g (xi, yi).
   </p>
 
   <p>
-    The reason for the money to have the form it does is so that Bob can check that it is signed by the bank. For each value of i Alice has to give him enough information to calculate xi and yi. If Bob choses a 1, she gives him ai and yi. Given ai Bob can calculate xi (=f(ai)), and with this and yi he can calculate g(xi,yi). If Bob chooses a 0, she gives him (ai xor &lt;info&gt;), as described before, and also xi. Given (ai xor &lt;info&gt;), Bob calculates yi (=f(ai xor &lt;info&gt;)), and with this and xi he can calculate g(xi,yi).
+    Então, para cada i, se Bob dá um 0 ou um 1, ele recebe informações suficientes para calcular g (xi, yi). Ele multiplica estes todos juntos e confirma que eles são iguais ao valor "dinheiro" original de Alice quando é levado ao 3º poder (lembre-se que o dinheiro foi produto de g (xi, yi) ^ (1/3) para todo i). Somente o banco poderia ter produzido uma assinatura nesta função unidirecional cujos argumentos assumem essa forma especial.
   </p>
 
   <p>
-    So for each i, whether Bob gives a 0 or a 1 he gets enough information to calculate g(xi,yi). He multiplies these all together and confirms that they are equal to Alice's original "money" value when it is taken to the 3rd power (recall the money was product of g(xi,yi)^(1/3) for all i). Only the bank could have produced a signature on this one-way function f whose arguments take this special form.
+    Mais uma complicação existe. (Bem, na verdade, um número quase infinito de complicações existe se você procurar bastante. Mas vamos nos focar em mais uma.) Alice precisa obter essa forma especial de dinheiro do banco de tal forma que o banco ganhou ' t reconhecê-lo. Isso significa que ela tem que cegar. Mas neste caso, o banco quer ter certeza de que o dinheiro é da forma adequada quando o assina; em particular, ele quer ter a certeza de que a <info> de Alice, que está enterrada em todos esses f's de g, é na verdade a mais adequada para ela. Mas como o banco não consegue ver o que está assinando, isso é difícil de fazer.
   </p>
 
   <p>
-    One more complication exists. (Well, actually, an almost infinite number of complications exist if you look hard enough. But we'll just focus on one more.) Alice needs to get this special form of money from the bank in such a way that the bank won't recognize it. That means she has to blind it. But in this case the bank wants to be sure that the money is of the proper form when it signs it; in particular, it wants to make darned sure that Alice's &lt;info&gt; which is buried deep in all of those f's of g's is actually the right one for her. But since the bank can't see what it is signing, this is hard to do.
+    Chaum usa corte-e-escolha para isso. Ele faz com que Alice prepare todos esses f e gs de acordo com o formulário acima, inserindo cuidadosamente sua própria <info> incriminadora em cada uma delas. Então ela multiplica cada g (xi, yi) por um fator de cegueira ri ^ 3 como no primeiro dinheiro. Estes são o que ela envia ao banco para ser assinado.
   </p>
 
   <p>
-    Chaum uses cut-and-choose for this. He has Alice prepare all these f's and g's according to the form above, carefully embedding her own incriminating &lt;info&gt; in each one. Then she multiplies each g(xi,yi) by a blinding factor ri^3 just like in the first cash. These are what she sends to the bank to be signed.
+    O truque, porém, é que ela envia o dobro do que será usado. Ela envia k deles, mas apenas k / 2 será usado. (É por isso que o loop acima usou k / 2 como limite). O banco escolhe k / 2 aleatoriamente do k que ela enviou como os que realmente serão usados. Alice então tem que enviar os valores de ri cegantes para aqueles que o banco não escolheu.
   </p>
 
   <p>
-    The trick, though, is that she sends twice as many as will be used. She sends k of them, but only k/2 will be used. (That's why the loop above used k/2 as the limit.) The bank chooses k/2 at random out of the k she sent as the ones which will actually be used. Alice then has to send the blinding ri values for the ones which the bank didn't pick.
+    A ideia é que, se Alice tentar enganar, incorporando "Bozo" em vez de "Alice" no campo <info>, ela está dando uma chance. Primeiro, para ser útil, ela terá que incorporá-lo em muitos campos <info> para valores diferentes de i. Quando Bob e Charlie comparam notas depois que ela gasta duas vezes, cada valor de i para o qual eles escolheram diferentes 0s e 1s, que estarão na metade média deles, revelará um campo <info>. Se ela só finge algumas, é provável que sua verdadeira identidade ainda seja revelada.
   </p>
 
   <p>
-    The idea is that if Alice tries to cheat, embedding "Bozo" instead of "Alice" in that &lt;info&gt; field, she's taking a chance. First, to be useful, she's going to have to embed it in a lot of &lt;info&gt; fields for different values of i. When Bob and Charlie compare notes after she double-spends, every value of i for which they chose different 0's and 1's, which will be on the average half of them, will reveal an &lt;info&gt; field. If she only fakes a few, chances are her real identity will still be revealed.
+    Mas se ela falsificar muitos deles, então quando o banco escolher metade, as chances são de que pelo menos alguns dos falsos estarão no set que o banco não escolheu. Então, quando Alice tiver que revelar seus rms ofuscantes, o gabarito estará pronto. O banco irá cegar todos aqueles g (xi, yi) que não estão sendo usados ​​e ver os falsos campos <info>.
   </p>
 
   <p>
-    But if she falsifies a great many of them, then when the bank chooses half, chances are at least some of the fake ones will be in the set the bank didn't choose. Then when Alice has to reveal her blinding r's, the jig will be up. The bank will un-blind all those g(xi,yi)'s which aren't being used, and see the fake &lt;info&gt; fields.
+    Essa metodologia de corte-e-escolha tem a desvantagem de que Alice precisa fazer o dobro de trabalho na preparação do dinheiro, metade da qual será jogada fora. Mas é uma maneira simples e "bruta" de certificar-se de que assinaturas ofuscantes estão sendo feitas em dados corretamente formados.
   </p>
 
   <p>
-    This cut-and-choose methodology has the disadvantage that Alice has to do twice as much work in preparing the money, half of which will just be thrown away. But it is a simple, "brute force" way to make sure that blinding signatures are actually being done on properly-formed data.
-  </p>
-
-  <p>
-    So, there you have it. Anonymity as long as you don't cheat, and double-spenders get caught. It's a little complicated but that's what computers are for; Bob and Alice wouldn't do all this stuff by hand. Alice would push the "generate a money candidate" button and get something to be sent to the bank (lots of the new PDA's have infrared wireless communications that would be perfect for face-to-face transactions). Bob would push the "check money" button when Alice spent it and it would flash red or green. As long as the calculations don't actually take too much time, which they really wouldn't in this case despite this long-winded explanation, the people involved can ignore the details.
+    Então, você tem isso. Anonimato, desde que você não trapaceie, e os que gastam com o dobro sejam pegos. É um pouco complicado, mas é para isso que os computadores são; Bob e Alice não fariam tudo isso a mão. Alice pressionaria o botão "gerar um candidato a dinheiro" e obteria algo para ser enviado ao banco (muitos dos novos PDAs têm comunicações sem fio infravermelhas que seriam perfeitas para transações face a face). Bob apertava o botão "cheque de dinheiro" quando Alice o gastava e ele piscava vermelho ou verde. Contanto que os cálculos não demorem muito tempo, o que eles realmente não fariam neste caso, apesar desta longa explicação, as pessoas envolvidas podem ignorar os detalhes.
   </p>
 
   <p>
@@ -153,7 +153,7 @@
   </p>
 
   <p>
-    <a href="http://finney.org/~hal/">Hal Finney Home Page</a>
+    <a href="http://finney.org/~hal/">Página de Hal Finney</a>
   </p>
 
 </div>

--- a/todo/for-pay-remailers.html
+++ b/todo/for-pay-remailers.html
@@ -4,76 +4,76 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
   <div class="page-header">
     <h1 class="text-center">
-      For-Pay Remailers<br><small>Hal Finney</small>
+      Remailers para pagar<br><small>Hal Finney</small>
     </h1>
     <h4 class="text-center">
-      October 28, 1994
+      28 de Outubro de 1994
     </h4>
   </div>
 
-{% filter markdown %}
-  What if you could make money by running a remailer?
+{% filter markdown %}</br>
+  E se você pudesse ganhar dinheiro executando um remailer? 
+  </br>
+  Neste momento, a maioria dos operadores de remailer está operando por altruísmo. Isso é bom em muitos aspectos, mas tem seus problemas, como os eventos recentes mostraram:
+  </br>
+* falta de motivação para manter os remailers operando diante de dificuldades e possíveis riscos legais </br>
+* facilidade de ataques de spam de usuários mal-intencionados </br>
+* falta de incentivo para um serviço de remailer de qualidade comercial</br> 
 
-  Right now, most remailer operators are operating out of altruism. This is good in a lot of ways but it has its problems, as recent events have shown:
-
-  * lack of motivation to keep remailers operating when faced with hassles and possible legal risks
-  * ease of spamming attacks by malicious users
-  * lack of incentive for a commercial-quality remailer service
-
-  I'm sure we can all think of more. I know that it would be a lot easier to justify continuing to run the remailer to myself if it were bringing in a few dollars a month.
-
-  I think there are some experiments in for-pay remailers that have been tried. Sameer is, I think, charging for some services, although paerhaps that was just for anonymous return addresses. A long time ago Karl Barrus had a service which required pre-issued "digital postage stamps", but I don't think many people used it.
-
-  The time may be ripe to look at this more seriously. Several factors are coming together:
-
-  * some efforts at standardization of remailer commands and cooperation of operators (e.g. this list)
-  * wider use of scripts and utility programs to help people use the remailers
-  several competing real-money systems which have come online just in the last month or so which * let you get paid for things on the net
-
-  To expand on these:
-
-  It is obviously difficult to operate a remailer service that charges if other people are offering the equivalent service for free. Since it is pretty easy to start up a remailer, the marginal cost to do so is low, hence the profits are low, too. However, although it is easy to start a remailer, it is not so easy to keep one running in the face of complaints from recipients of abusive mail or inappropriate posts; hassles from sysops, owners, net feeds, or others upwards in that great chain of command; possible law enforcement problems when illegal communications occur; possible threats of lawsuits (such as from the scientologists when their sacred documents are posted), etc. So we should not be misled into thinking that running a remailer is cost free.
-
-  On the other hand I should be clear that I would not expect to make a killing on this service. Something on the order of a penny a message seems reasonable just at a guess. Maybe it should be a factor of 10 higher or lower.
-
-  One issue is of course the additional difficulty this will cause in the use of the remailer. There are several things to consider here. On the one hand you could argue that it is already too difficult to use the remailers, and any additional hassles involved with including some kind of payment tokens would kill the market. OTOH I can agree in spirit with the sentiments expressed here recently about the low quality which seems to characterize much of the use of the remailers.
-
-  I don't look at messages, but occasionally I do see bounces, and very frequently they are ugly little flames or similar worthless material. Now, I hope that I am seeing the dregs, that the kinds of clueless people who make the mistakes which cause me to see the messages are the ones least likely to use the service in a worthwhile manner. But still, it is discouraging. In that context, maybe making the system a little harder to use would be worthwhile, in that it would screen out the casual harrasser. (Or, more realistically, this might just keep the exceptionally motivated harrassers.)
-
-  In any case, I think the presence of the remailer scripts can make using a for-pay remailer not much more difficult than using a free one. If the cost is as low as I suggested and the inclusion of payment tokens is nearly automatic, then adding costs should not have much negative impact on use, certainly not on meaningful, worthwhile use.
-
-  And even a modest cost might arrest the wholesale spamming that Detweiler and/or the recent "Scythe" seem to love. At least we would be paid for enduring the hassle of the complaints.
-
-  Now, the next question is the details of the payment. Frankly, I don't think any of the current systems are quite right for us due to our special needs, but things are changing rapidly. Let me describe something about how they work.
-
-  I know of two systems that are VISA/Mastercard based. One is called First Virtual ([http://www.fv.com](http://www.fv.com)). They are oriented towards information sales and say that they aren't for service providers, but in practice it looked to me like they could be used for services. When a customer wants to pay, he sends you his FV ID. You send this to FV and they send an email message to the customer asking whether he authorizes the payment. If he says "yes", FV credits your account. You get a check every month. Customers who always say "no" get booted out of the system (as do merchants who submit bogus bills). They charge 29 cents plus 2 percent per transaction, but merchants can batch up multiple orders by a single customer before sending it in.
-
-  There are a few problems with a system like this, many of which are somewhat generic to our situation. The most fundamental is that we don't know who our customers are much of the time. In fact, the whole point of the remailer network is that we not know that fact for any case except the first hop in the chain. If we required customers to expose their FV account ID at every hop, it would make it a lot easier to track messages through the network (even if the ID's were hidden in the encryption envelope it seems risky). If we then sent a message to FV saying that we needed to charge ID XXX, and FV responds with an email to the person's home address, this offers more possibilities for tracing.
-
-  One solution would be only to charge on entry into the remailer net. Perhaps remailer operators would even charge each other then, and the first remailer would charge some larger amount to deal with a "typical" chain length? Many interesting possibilities here.
-
-  Another issue is that the overhead charges by FV would require batching up messages before submitting them. Let me make clear that the batch must consist all of charges to a single user. It doesn't do any good to send one message to FV asking them to please charge a penny to each of 100 VISA accounts. No, you would have to count messages from each user, separately, and when user XXX had sent, say, $1 worth of messages, you could send in the request to FV and get back 70 or so cents.
-
-  So this adds some overhead and record-keeping that we don't currently have to do, although perhaps it is not so difficult. But it would raise new questions of authenticating FV ID's, and shares some of the negative privacy impacts and message linking issues mentioned above.
-
-  The other VISA based system is called OpenMarket. I just read about it tonight so I don't know it as well ([http://www.openmarket.com](http://www.openmarket.com)). It is pretty tied to the WWW so it would not seem to work for us. Customers get connected to a particular WWW server which authenticates them and charges their VISA card appropriately, then they get redirected to the merchant with some kind of token that says they have paid.
-
-  The NetBank (email to netbank-intro@agents.com) is a digital-cash like system. Customers get tokens which are basically large secret numbers which have a cash value. They send them to the merchants, and the merchants then send them to the bank which credits their account. The NetBank sends you a check every month.
-
-  The interesting thing is how customers buy the cash tokens. One way is by connecting to a 900 number with your modem. They charge the customer $10.00 and give him a digital cash token worth that much. Another way is by faxing a check to them. I wasn't clear on how you get the cash token back in that case; I guess they email it to you at an address you specify. From the privacy point of view, these are not that great; 900 numbers have Automatic Number Identification so unless you are willing to tramp out to a pay phone to get your cash then it could be linked to your phone number. And the fax system must have some kind of return address that would link to you.
-
-  The other problem with NetBank is that the smallest denomination which can be spent is 25 cents. Due to the cash-like nature of the tokens, I don't see a natural way to accumulate several messages into one payment. Maybe we could layer our own low-value digital cash system on top of NetBank, where users could buy our anonymous cash for 25 cents and get enough tokens for 25 messages, then we would settle amongst ourselves (or actually with the anon-mail-token bank). Actually this might help with the privacy problems, too. Anonymous digital cash is heavily patented, though.
-
-  With a cash-like system, each message would include a numeric token in the header which is the digital cash. The remailer would strip that out and send it in for credit. This is a simple system and could be largely automatic. However there are some tricky issues about cheaters re-using cash.
-
-  NetBank charges $4 per month, plus, for the 900-number-based cash, 20% off of face value.
-
-  The last system I'll describe is David Chaum's DigiCash ([http://www.digicash.com](http://www.digicash.com)). Chaum is the inventor of digital cash and he certainly knows his stuff, plus as I said he has the intellectual property pretty well sewed up patent-wise. The DC payment system is also WWW based at present. The customer has to be running a special program on his computer, separate from his web browser. This program holds his digital cash, which is similar conceptually to the NetBank cash but more sophisticated cryptographically. When he wants to buy something, the merchant's web server makes a connection to the customer's DC program, and it transfers the cash to the merchant.
-
-  DigiCash says they are planning an email based system but for now their emphasis is on the WWW. Right now they are only in beta and not using real money. I don't know when they will be real and email based, and I don't know if they have said what their commission will be. But when this comes up it may be the best approach if small-value transactions can be supported. DigiCash is fully anonymous in the sense that once a customer receives the money, it is "blinded" in a special cryptographic way so that the bank cannot associate it with that customer (and no one else can, either). This kind of anonymity fits in very well with our remailer requirements.
-
-  Well, I know this is a lot of information to work through, but mostly I want people to be aware of the possibilities. Most of this stuff is very, very new, only weeks old, generally. Probably over the next few months we will see a lot more options appear. I am confident that there will soon be payment systems that would provide the technical basis for fee based remailing. I don't expect anyone to get rich by this, but it might help compensate for the risks we all face, and it might serve to improve the quality of the remailer network.
-  {% endfilter %}
+Tenho certeza de que todos podemos pensar em mais. Eu sei que seria muito mais fácil justificar continuar a administrar o repostador a mim mesmo se ele trouxesse alguns dólares por mês. 
+</br>
+Eu acho que existem alguns experimentos em remailers pagos que foram tentados. Penso que Sameer está cobrando por alguns serviços, embora talvez fosse apenas para endereços de retorno anônimos. Há muito tempo atrás, Karl Barrus tinha um serviço que exigia "selos digitais" pré-emitidos, mas não creio que muitas pessoas o usassem. 
+</br>
+O tempo pode estar maduro para encarar isso com mais seriedade. Vários fatores estão se unindo: 
+</br>
+* alguns esforços na padronização de comandos de remailer e cooperação de operadores (por exemplo, esta lista) </br>
+* uso mais amplo de scripts e programas utilitários para ajudar as pessoas a usarem os remailers em </br>
+vários sistemas de dinheiro real que estão on-line último mês ou assim que * permitem que você seja pago por coisas na net 
+</br>
+  Para ser mais específico: 
+  </br>
+É obviamente difícil operar um serviço de reencaminhamento que cobra se outras pessoas oferecerem o serviço equivalente gratuitamente. Como é muito fácil iniciar um remailer, o custo marginal para fazer isso é baixo, por isso os lucros também são baixos. No entanto, embora seja fácil iniciar um repostador, não é tão fácil manter uma execução em face de reclamações de destinatários de mensagens abusivas ou postagens inadequadas; dificuldades de sysops, proprietários, feeds de rede, ou outros para cima nessa grande cadeia de comando; possíveis problemas de aplicação da lei quando ocorrem comunicações ilegais; possíveis ameaças de ações judiciais (tais como dos cientologistas quando seus documentos sagrados são postados), etc. Portanto, não devemos ser enganados em pensar que a execução de um repostador é gratuita. 
+</br>
+Por outro lado, devo deixar claro que não esperaria uma morte neste serviço. Algo na ordem de um centavo uma mensagem parece razoável apenas em um palpite. Talvez devesse ser um fator de 10 maior ou menor. 
+</br>
+Uma questão é, evidentemente, a dificuldade adicional que isso causará no uso do repostador. Há várias coisas a considerar aqui. Por um lado, você poderia argumentar que já é muito difícil usar os remailers, e qualquer complicação adicional envolvida em incluir algum tipo de tokens de pagamento acabaria com o mercado. OTOH Eu posso concordar em espírito com os sentimentos expressos aqui recentemente sobre a baixa qualidade que parece caracterizar muito do uso dos remailers. 
+</br>
+Não olho para mensagens, mas de vez em quando vejo saltos, e com muita frequência são pequenas chamas feias ou material sem valor semelhante. Agora, espero ver os resíduos, que os tipos de pessoas sem noção que cometem os erros que me levam a ver as mensagens são os menos propensos a usar o serviço de uma maneira que vale a pena. Mas ainda assim, é desanimador. Nesse contexto, talvez tornar o sistema um pouco mais difícil de usar valeria a pena, na medida em que filtraria o harrasser casual. (Ou, mais realisticamente, isso pode manter apenas os harrassers excepcionalmente motivados.) 
+</br>
+De qualquer forma, acho que a presença dos scripts de remailer pode fazer com que usar um remailer para pagamento não seja muito mais difícil do que usar um programa gratuito. Se o custo for tão baixo quanto sugeri e a inclusão de tokens de pagamento for quase automática, a adição de custos não deverá ter um impacto muito negativo sobre o uso, certamente não em uso significativo e válido. 
+</br>
+E mesmo um custo modesto pode deter o spam que Detweiler e / ou a recente "Scythe" parecem amar. Pelo menos seríamos pagos por suportar o incômodo das reclamações. 
+</br>
+Agora, a próxima pergunta é os detalhes do pagamento. Francamente, não creio que nenhum dos sistemas atuais seja adequado para nós devido a nossas necessidades especiais, mas as coisas estão mudando rapidamente. Deixe-me descrever algo sobre como eles funcionam. 
+</br>
+Eu sei de dois sistemas que são baseados em VISA / Mastercard. Um é chamado First Virtual ([http://www.fv.com] (http://www.fv.com)). Eles são orientados para a venda de informações e dizem que não são para prestadores de serviços, mas, na prática, pareciam-me que poderiam ser usados ​​para serviços. Quando um cliente quer pagar, ele lhe envia seu ID de FV. Você envia isso para o FV e eles enviam uma mensagem de e-mail para o cliente perguntando se ele autoriza o pagamento. Se ele disser "sim", o FV creditará sua conta. Você recebe um cheque todo mês. Os clientes que sempre dizem "não" saem do sistema (assim como os comerciantes que enviam notas falsas). Eles cobram 29 centavos mais 2% por transação, mas os comerciantes podem agrupar vários pedidos de um único cliente antes de enviá-lo. 
+</br>
+Existem alguns problemas com um sistema como este, muitos dos quais são um pouco genéricos para a nossa situação. O mais fundamental é que não sabemos quem são nossos clientes na maior parte do tempo. De fato, o ponto principal da rede de remailers é que não conhecemos esse fato em nenhum caso, exceto o primeiro salto na cadeia. Se exigíssemos que os clientes expusessem sua ID de conta FV em cada salto, seria muito mais fácil rastrear mensagens através da rede (mesmo que as identificações estivessem escondidas no envelope de criptografia, parece arriscado). Se, em seguida, enviarmos uma mensagem ao FV dizendo que precisamos cobrar o ID XXX e o FV responder com um e-mail ao endereço residencial da pessoa, isso oferece mais possibilidades de rastreamento. 
+</br>
+Uma solução seria apenas cobrar ao entrar na rede de repotenciação. Talvez os operadores de reencaminhamento cobrassem um ao outro, e o primeiro remailer cobraria uma quantia maior para lidar com um comprimento "típico" da cadeia? Muitas possibilidades interessantes aqui. 
+</br>
+Outra questão é que as despesas indiretas por FV exigiriam mensagens em lote antes de enviá-las. Deixe-me esclarecer que o lote deve consistir em todos os encargos para um único usuário. Não adianta enviar uma mensagem para o FV, pedindo-lhe para, por favor, cobrar um centavo para cada uma das 100 contas do VISA. Não, você teria que contar as mensagens de cada usuário, separadamente, e quando o usuário XXX tivesse enviado, digamos, US $ 1 em mensagens, você poderia enviar a solicitação para o FV e receber 70 centavos de dólar. 
+</br>
+Então isso adiciona um pouco de overhead e manutenção de registros que atualmente não temos que fazer, embora talvez não seja tão difícil. Mas isso levantaria novas questões sobre a autenticação de IDs de FV e compartilha alguns dos impactos negativos de privacidade e problemas de links de mensagens mencionados acima. 
+</br>
+O outro sistema baseado em VISA é chamado OpenMarket. Acabei de ler sobre isso hoje à noite, então eu não sei também (http://www.openmarket.com) (http://www.openmarket.com)). É muito ligado à WWW, então não parece funcionar para nós. Os clientes se conectam a um determinado servidor WWW que os autentica e cobra seu cartão VISA adequadamente, então eles são redirecionados para o comerciante com algum tipo de token que diz que eles pagaram. 
+</br>
+O NetBank (e-mail para netbank-intro@agents.com) é um sistema similar a dinheiro digital. Os clientes obtêm tokens que são basicamente grandes números secretos que possuem um valor em dinheiro. Eles os enviam para os comerciantes, e os comerciantes os enviam para o banco que credita a conta. O NetBank envia um cheque todo mês. 
+</br>
+O interessante é como os clientes compram os tokens em dinheiro. Uma maneira é se conectar a um número 900 com o seu modem. Eles cobram do cliente US $ 10,00 e dão a ele um valor em dinheiro digital que vale muito. Outra maneira é enviando um cheque por fax para eles. Eu não estava claro sobre como você recebe a ficha em dinheiro nesse caso; Eu acho que eles enviam para você em um endereço que você especificar. Do ponto de vista da privacidade, eles não são tão bons assim; Os números 900 têm Identificação Automática de Número, a menos que você esteja disposto a sair para um telefone público para receber seu dinheiro, então ele pode estar ligado ao seu número de telefone. E o sistema de fax deve ter algum tipo de endereço de retorno que seja vinculado a você. 
+</br>
+O outro problema com o NetBank é que a menor denominação que pode ser gasta é de 25 centavos. Devido à natureza de caixa dos tokens, não vejo uma maneira natural de acumular várias mensagens em um único pagamento. Talvez pudéssemos colocar nosso próprio sistema de dinheiro digital de baixo valor em cima do NetBank, onde os usuários poderiam comprar nosso dinheiro anônimo por 25 centavos e receber fichas suficientes para 25 mensagens, então nós resolveríamos entre nós (ou na verdade com o anon-mail- token bank). Na verdade, isso pode ajudar com os problemas de privacidade também. O dinheiro digital anônimo é altamente patenteado, no entanto. 
+</br>
+Com um sistema similar a dinheiro, cada mensagem incluiria um token numérico no cabeçalho, que é o dinheiro digital. O remailer iria retirar isso e enviá-lo para o crédito. Este é um sistema simples e pode ser amplamente automático. No entanto, existem algumas questões complicadas sobre os trapaceiros reutilizarem dinheiro. 
+</br>
+O NetBank cobra US $ 4 por mês, mais, para o caixa baseado em 900, 20% de desconto no valor de face. 
+</br>
+O último sistema que descreverei é o DigiCash de David Chaum (http://www.digicash.com) (http://www.digicash.com). Chaum é o inventor do dinheiro digital e ele certamente conhece suas coisas, além disso, como eu disse, ele tem a propriedade intelectual muito bem costurada em termos de patentes. O sistema de pagamento da DC também é baseado na WWW atualmente. O cliente tem que estar executando um programa especial em seu computador, separado de seu navegador. Este programa mantém seu dinheiro digital, que é similar conceitualmente ao caixa do NetBank, porém mais sofisticado criptograficamente. Quando ele quer comprar algo, o servidor da Web do comerciante faz uma conexão com o programa de DC do cliente e transfere o dinheiro para o comerciante. 
+</br>
+DigiCash disse que eles estão planejando um sistema baseado em e-mail, mas por enquanto sua ênfase é na WWW. No momento, eles estão apenas em beta e não usam dinheiro real. Eu não sei quando eles serão reais e baseados em e-mail, e não sei se eles disseram qual será a comissão deles. Mas quando isso acontece, pode ser a melhor abordagem se transações de valor pequeno puderem ser suportadas. O DigiCash é totalmente anônimo no sentido de que, uma vez que um cliente recebe o dinheiro, ele fica "cego" de uma maneira criptográfica especial, de modo que o banco não possa associá-lo a esse cliente (e ninguém mais pode, também). Esse tipo de anonimato se encaixa muito bem com nossos requisitos de remailer. 
+</br>
+Bem, eu sei que isso é muita informação para trabalhar, mas principalmente eu quero que as pessoas estejam cientes das possibilidades. A maioria dessas coisas é muito, muito nova, com apenas algumas semanas de idade, geralmente. Provavelmente nos próximos meses veremos muito mais opções. Estou confiante de que em breve haverá sistemas de pagamento que fornecerão a base técnica para o reencaminhamento baseado em taxas. Eu não espero que ninguém fique rico com isso, mas isso pode ajudar a compensar os riscos que todos enfrentamos, e pode servir para melhorar a qualidade da rede de remailers. 
+  </br>{% endfilter %}
 
   <p>
     Hal Finney<br>
@@ -81,7 +81,7 @@
   </p>
 
   <p>
-    <a href="http://web.archive.org/web/20130624115154/http://finney.org/~hal/home.html">Hal Finney Home Page</a>
+    <a href="http://web.archive.org/web/20130624115154/http://finney.org/~hal/home.html">Página de Hal Finney</a>
   </p>
 
 </div>

--- a/todo/negative-reputation.html
+++ b/todo/negative-reputation.html
@@ -4,7 +4,7 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
   <div class="page-header">
     <h1 class="text-center">
-  	  Negative Reputation<br><small>Nick Szabo</small>
+  	  Reputação negativa<br><small>Nick Szabo</small>
   	</h1>
   	<h4 class="text-center">
   	  1996<br>
@@ -12,82 +12,82 @@
   </div>
 
   <p>
-    An important and general problem seems to be that of tagging a negative behavior source for future recognition. The tag might be used for negative information shared publically (eg, credit ratings) or kept private (eg, kill files). The behavior source might be non-human (eg, recognizing virus patterns for the purposes of virus scanning). Where the behavior source is adaptable and self-interested, it has an incentive to spoof the tagging: a debtor to change names to avoid paying his debt, a virus to scramble its pattern to avoid scanning, and so on. If the tag carries a greater positive reputation (where zero is the reputation of a newcomer) this incentive is lost and the negative side of the reputation — the disreputation — must be borne.
+    Um problema importante e geral parece ser o de marcar uma fonte de comportamento negativo para reconhecimento futuro. A tag pode ser usada para informações negativas compartilhadas publicamente (por exemplo, classificações de crédito) ou mantidas em sigilo (por exemplo, matar arquivos). A fonte de comportamento pode ser não humana (por exemplo, reconhecer padrões de vírus para fins de verificação de vírus). Onde a fonte de comportamento é adaptável e interessada, ela tem um incentivo para falsificar a marcação: um devedor para mudar nomes para evitar pagar suas dívidas, um vírus para embaralhar seu padrão para evitar varredura, e assim por diante. Se a tag tiver uma reputação positiva maior (onde zero é a reputação de um recém-chegado), esse incentivo será perdido e o lado negativo da reputação - a falta de reputação - deve ser suportado.
   </p>
 
   <p>
-    Can digital credentialling systems facilitate such negative reputation handling?
+    Os sistemas de credenciamento digital podem facilitar esse tratamento negativo da reputação?
   </p>
 
   <p>
-    Service-specific, aka local, nym reputation may not be able to accomplish such tracking of negative reputation. If a local nym accumulates more negative than positive credentials, it can simply be replaced by a newcomer local nym for this service, without harming the positive reputation capital of the other behavior source local nyms. Hostile sources can continuously spoof innocent newcomers. Counterparties lose the ability to determine a history of previous hostile behavhior — kill files, virus scanning, credit ratings, etc. fail.
+    Reputação específica do serviço, também conhecida localmente, pode não ser capaz de realizar esse rastreamento de reputação negativa. Se um nym local acumular mais credenciais negativas do que positivas, ele pode simplesmente ser substituído por um nym local recém-chegado para este serviço, sem prejudicar o capital de reputação positivo dos nyms locais de outras fontes de comportamento. Fontes hostis podem continuamente falsificar novatos inocentes. As contrapartes perdem a capacidade de determinar um histórico de arquivos hostis de morte anterior, varredura de vírus, classificações de crédito, etc.
   </p>
 
   <p>
-    <a href="http://www.chaum.com/publications/Security_Wthout_Identification.html">Chaumian credentials</a> also give the credential holder control over the transfer of credentials between his local nyms, creating an incentive to show positive credentials and hide negative ones. To remedy this, counterparties can demand "non-negative credentials" (in a form such as, "Alice in many transactions recorded by me in area X has never done bad things x,y,z"), Non-negative credentials are limited to areas that can be well-tracked. One such may be credit ratings, as long as one is doing the bulk of one's credit transactions through is-a-person linked local nyms.
+    As <a href="http://www.chaum.com/publications/Security_Wthout_Identification.html">credenciais chaumianas</a> também dão ao titular da credencial o controle sobre a transferência de credenciais entre seus nyms locais, criando um incentivo para mostrar credenciais positivas e ocultar as negativas. Para remediar isso, as contrapartes podem exigir "credenciais não-negativas" (em uma forma como "Alice em muitas transações registradas por mim na área X nunca fez coisas ruins x, y, z"), credenciais não-negativas são limitadas para áreas que podem ser bem controladas. Uma delas pode ser a classificação de crédito, desde que uma esteja fazendo a maior parte das transações de crédito através de nyms locais ligados a uma pessoa.
   </p>
 
   <p>
-    Where Chaumian credentials are inapplicable, we might raise the cost of entry to be greater than that of a newcomer. This gives us two clearly defined reputation points to compare on an otherwise rather subjective scale: participation threshold and newcomer reputation. Both are subjective in the eye of the party choosing whether or not to participate in an activity with the nym.
+    Onde as credenciais de Chaumian são inaplicáveis, podemos aumentar o custo de entrada para ser maior do que o de um recém-chegado. Isso nos dá dois pontos de reputação claramente definidos para comparar em uma escala bastante subjetiva: limite de participação e reputação de recém-chegado. Ambos são subjetivos no olho da parte que escolhe se quer ou não participar de uma atividade com o nym.
   </p>
 
   <p>
-    A participation threshold greater than newcomer reputation clashes with the desirable goal, that one be able to make a fresh start. For that matter, unless previous nyms and their positive reputations are linked to their new nyms, the pioneers cannot make a start, so that the institution itself cannot be started. Ditto for for institutional growth.
+    Um limiar de participação maior do que a reputação de recém-chegados se choca com o objetivo desejável, que é capaz de fazer um novo começo. Aliás, a menos que os nyms anteriores e suas reputações positivas estejam ligadas a seus novos nyms, os pioneiros não podem começar, de modo que a própria instituição não possa ser iniciada. O mesmo vale para o crescimento institucional.
   </p>
 
   <p>
-    Tags that bundle the results of a wide variety of transactions — global nyms, aka universal IDs, aka "True Names" — seem to provide the most incentive for parties to carry their negative credentials. Most people have accumulated enough positive reputation is some areas that it is well-nigh impossible for them to start over their entire lives as newcomers.
+    Tags que agrupam os resultados de uma ampla variedade de transações - nyms globais, também conhecidos como IDs universais, também conhecidos como "Nomes Verdadeiros" - parecem fornecer o maior incentivo para que as partes carreguem suas credenciais negativas. A maioria das pessoas acumulou reputação positiva suficiente em algumas áreas que é quase impossível para eles começarem suas vidas inteiras como recém-chegados.
   </p>
 
   <p>
+    Um grande problema surge com credenciais negativas quando elas são usadas, não apenas para evitar a participação em uma atividade específica com uma parte, mas para retaliação contra essa parte. A retribuição pode tomar alguma forma on-line não violenta, como calúnia, ataque de negação de serviço e assim por diante, mas a forma mais preocupante de retribuição é um ataque físico violento. Poderíamos ter marcas digitais que, enquanto rastreavam fontes de comportamento negativo no mundo digital, permanecessem estritamente desvinculadas de qualquer tipo de dados de localização física? Infelizmente, temos vários sistemas importantes, como telefones celulares, endereços de envio, etc., que fornecem essa ligação.
+  </p>
+
+<!-- <p> LINHA DUPLICADA SEM RAZÃO APARENTE
     A big problem arises with negative credentials when they are used, not merely to avoid engaging in a particular activity with a party, but for retribution against that party. Retribution may take some nonviolent online form, such as slander, denial of service attack, and so on, but the most worrisome form of retribution is a violent physical attack. Could we have digital tags that, while tracking negative behavior sources through the digital world, remain strictly unlinked to any kind of physical location data? Alas, we have several important systems, such as cellular phones, shipping addresses, etc. that provide such linkage.
-  </p>
+  </p> -->
 
   <p>
-    A big problem arises with negative credentials when they are used, not merely to avoid engaging in a particular activity with a party, but for retribution against that party. Retribution may take some nonviolent online form, such as slander, denial of service attack, and so on, but the most worrisome form of retribution is a violent physical attack. Could we have digital tags that, while tracking negative behavior sources through the digital world, remain strictly unlinked to any kind of physical location data? Alas, we have several important systems, such as cellular phones, shipping addresses, etc. that provide such linkage.
-  </p>
-
-  <p>
-    The question may become one of deciding what of these three dimensions are most important, and how they can be traded off:
+    A questão pode ser a de decidir quais destas três dimensões são mais importantes e como podem ser trocadas:
   </p>
 
   <p>
     <ul>
-      <li>The gains to be had from tracking and thereby avoiding negative behavior sources</li>
-      <li>The gains to be had from a nonviolent digital world (ie, a virtual realm within which any digital action can have no physically violent consequences).</li>
-      <li>The inconvenience (and perhaps impracticality) of partitioning the physical and digital worlds into different ID systems (more realistically, some "pure" subset of the digital world completely partitioned from location devices, physical shipping information, etc.)</li>
+      <li>Os ganhos a serem obtidos de rastreamento e, assim, evitar fontes de comportamento negativo</li>
+      <li>Os ganhos a serem obtidos a partir de um mundo digital não violento (isto é, um reino virtual no qual qualquer ação digital não pode ter consequências fisicamente violentas).</li>
+      <li>A inconveniência (e talvez impraticabilidade) de particionar os mundos físico e digital em diferentes sistemas de ID (mais realisticamente, algum subconjunto "puro" do mundo digital completamente particionado a partir de dispositivos de localização, informações físicas de envio, etc.)</li>
     </ul>
   </p>
 
   <p>
-    Keep in mind too, that in practice these are evaluated primarily by a market evolving from its current state, rather than by abstract ethical philosophies.
+    Tenha em mente também que, na prática, elas são avaliadas principalmente por um mercado que evolui de seu estado atual, e não por filosofias éticas abstratas.
   </p>
 
   <p>
-    Robin Hanson has noted that in a world of global nyms, the use of a local nym may signal the hiding of negative credentials, so that the use of global nyms is in equilibrium. A further problem with local nyms is that our relationships are often not neatly compartmentalizable into standard service types, and even where they are we might like to expand them into new areas. I suggest that, at minimum, we will want to reveal progressively more local nyms to our counterparties as our relationships with them become closer and more co-exposed.
+   Robin Hanson observou que, em um mundo de nyms globais, o uso de um nym local pode sinalizar a ocultação de credenciais negativas, de modo que o uso de nyms globais esteja em equilíbrio. Um outro problema com os nyms locais é que nossos relacionamentos muitas vezes não são perfeitamente compartimentáveis ​​em tipos de serviço padrão, e até onde eles estão, gostaríamos de expandi-los em novas áreas. Sugiro que, no mínimo, vamos querer revelar progressivamente mais nyms locais às nossas contrapartes, à medida que nossos relacionamentos com eles se tornarem mais próximos e mais coexpostos.
   </p>
 
   <p>
-  While the global nym equilibrium may hold for many of our relationships, there may be plenty of areas where the <a href="http://szabo.best.vwh.net/smart_contracts_glossary.html#privity">privity</a> benefits of localizing nyms outweigh the costs of being less or unable to differentiate newcomers from hostiles. (By "privity" I refer the entire general task of protecting relationships from hostile third parties; confidentiality and protection of property from theft are two examples of privity). For example, the preference-tracking service at www.firefly.com increases participation via the use of pseudonyms, and suffers little exposure from hostiles. On the other hand, credit transactions typically demand identifying information, because the contractual exposure typically outweighs benefits of privity.
+  Enquanto o equilíbrio nym global pode manter por muitos de nossos relacionamentos, pode haver muitas áreas onde os benefícios da <a href="http://szabo.best.vwh.net/smart_contracts_glossary.html#privity">privacidade</a> de localizar nyms superam os custos de ser menor ou incapaz de diferenciar os recém-chegados de inimigos. (Por "prividade" eu me refiro a toda a tarefa geral de proteger as relações de terceiros hostis; confidencialidade e proteção de propriedade contra roubo são dois exemplos de privacidade). Por exemplo, o serviço de rastreamento de preferências em www.firefly.com aumenta a participação por meio do uso de pseudônimos e sofre pouca exposição de hostis. Por outro lado, as transações de crédito normalmente exigem informações de identificação, porque a exposição contratual normalmente supera os benefícios da privacidade.
   </p>
 
   <p>
-    Global nym public keys, which have many drawbacks in terms of privity, may be the best way to track negative reputation, but they are no panacea. There is an important conundrum in an ID-based key system: the conflict between the ability to get a new key when the old one is or could be abused by another (key revocation), and the ability of another to be sure they are dealing with the same person again. This may also provide an opportunity for parties to selectively reveal positive credentials and hide negative ones. For example, a person with a bad credit rating could revoke the key under which that rating is distributed and create a new one, while selectively updating their positive credentials to the new key (eg, have their alma mater create a new diploma). Key revocation <a href="http://szabo.best.vwh.net/authorities.html">authorities</a> might combine forces with credit rating agencies to avoid such erasure of negative history, but this gives them even more centralized control — not merely over IDs but over important elements of reputation associated with those IDs. This further violates the principles of separation of powers and segregation of duties, providing added opportunity for fraudulent issue or revocation of IDs along with fraudulent communication of reputation information.
+    As chaves públicas globais da nym, que têm muitas desvantagens em termos de privacidade, podem ser a melhor maneira de rastrear a reputação negativa, mas não são uma panacéia. Há um enigma importante em um sistema de chaves baseado em ID: o conflito entre a capacidade de obter uma nova chave quando a antiga é ou pode ser abusada por outra (revogação da chave) e a capacidade de outra ter certeza de estar lidando com ela. com a mesma pessoa novamente. Isso também pode oferecer uma oportunidade para as partes revelarem seletivamente credenciais positivas e ocultarem as negativas. Por exemplo, uma pessoa com uma classificação de crédito ruim pode revogar a chave sob a qual essa classificação é distribuída e criar uma nova, enquanto atualiza seletivamente suas credenciais positivas para a nova chave (por exemplo, fazer com que sua alma mater crie um novo diploma). <a href="http://szabo.best.vwh.net/authorities.html">Autoridades</a> de revogação de chave podem combinar forças com agências de classificação de crédito para evitar esse apagamento da história negativa, mas isso lhes dá um controle ainda mais centralizado - não apenas sobre identidades, mas sobre importantes elementos de reputação associados a esses documentos. Isso viola ainda mais os princípios da separação de poderes e da segregação de funções, proporcionando uma oportunidade adicional para a emissão fraudulenta ou revogação de identidades, juntamente com a comunicação fraudulenta de informações de reputação.
   </p>
 
   <p>
-    The current universal (non-cryptographic) key in the U.S., the SSN, is very difficult to revoke. Much easier to change your name. This policy is probably no accident, since the biggest economic win of global nym identification is the tracking of negative reputations, which revocation can defeat. As long as the SSN is a shared database key, not used for the purpose of securely identifying a faceless transaction, there is little need for revocation beyond the undesired erasure of negative history. Combining a secret authentication key, which must be revocable, with a public universal ID is quite problematic.
-  </p>
+    A chave universal (não criptográfica) universal nos EUA, o SSN, é muito difícil de revogar. Muito mais fácil mudar seu nome. Essa política provavelmente não é um acidente, já que a maior vitória econômica da identificação global de nim é o rastreamento de reputações negativas, que a revogação pode derrotar. Enquanto o SSN for uma chave de banco de dados compartilhada, não usada com a finalidade de identificar com segurança uma transação sem rosto, há pouca necessidade de revogação além do apagamento indesejado do histórico negativo. Combinar uma chave de autenticação secreta, que deve ser revogável, com uma ID universal pública é bastante problemática.
+	</p>
 
   <hr>
 
     <p>
-      Please send your comments to nszabo (at) law (dot) gwu (dot) edu
+      Por favor, envie seus comentários para nszabo@law.gwu.edu
     </p>
 
     <p>
-      Copyright &copy; 1996 by Nick Szabo<br>
-      Permission to redistribute without alteration hereby granted
+      Direito autoral &copy; 1996 por Nick Szabo<br>
+      Permissão para redistribuir sem alteração previamente concedida.
     </p>
 </div>
 {% endblock %}

--- a/todo/online-cash-checks.html
+++ b/todo/online-cash-checks.html
@@ -13,144 +13,144 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
   <div class="page-header">
     <h1 class="text-center">
-      Online Cash Checks <br><small>David Chaum</small>
+      Verificações de dinheiro online <br><small>David Chaum</small>
     </h1>
     <h4 class="text-center">
       1989<br>
     </h4>
   </div>
 
-  <h3>Introduction</h3>
+  <h3>Introdução</h3>
 
   <p>
-    Savings of roughly an order of magnitude in space, storage, and bandwidth over previously published online electronic cash protocols are achieved by the techniques introduced here. In addition, these techniques can increase convenience, make more efficient use of funds, and improve privacy.
+    Economias de aproximadamente uma ordem de grandeza em espaço, armazenamento e largura de banda sobre protocolos de dinheiro eletrônico on-line publicados anteriormente são alcançadas pelas técnicas aqui apresentadas. Além disso, essas técnicas podem aumentar a conveniência, fazer uso mais eficiente dos recursos e melhorar a privacidade.
   </p>
 
   <p>
-    "Offline" electronic money<sup><a href="#fnCFN88" id="refCFN88">[CFN88]</a></sup> is suitable for low value transactions where "accountability after the fact" is sufficient to deter abuse; online payment<sup><a href="#fnC89" id="refC89-1">[C89]</a></sup>, however, remains necessary for transactions that require "prior restraint" against persons spending beyond their available funds.
+    O dinheiro eletrônico "off-line"<sup><a href="#fnCFN88" id="refCFN88">[CFN88]</a></sup> é adequado para transações de baixo valor, em que a "prestação de contas após o fato" é suficiente para impedir o abuso; o pagamento on-line<sup><a href="#fnC89" id="refC89-1">[C89]</a></sup>, no entanto, continua sendo necessário para transações que exigem "restrição prévia" contra pessoas que gastam além de seus fundos disponíveis.
+	</p>
+
+  <p>
+    Três esquemas online são apresentados aqui. Cada um depende das mesmas técnicas para codificar as denominações em assinaturas e para "desvalorizar" as assinaturas para o valor exato escolhido no momento do pagamento. Eles diferem em como o valor não gasto é devolvido ao pagador. No primeiro, todas as alterações são acumuladas pelo pagador em um único "pote de biscoitos", que pode ser depositado no banco durante a próxima transação de retirada. Os segundo e terceiro esquemas permitem que a mudança seja distribuída entre as notas não gastas, que podem depois ser gastas. O segundo esquema revela à loja e ao banco o montante máximo pelo qual uma nota pode ser gasta; o terceiro não divulga essa informação.
+	</p>
+
+  <h3>Denominações e desvalorização</h3>
+
+  <p>
+    Por simplicidade e concretude, mas sem perda de generalidade, um esquema de denominação particular será usado aqui. Atribui o valor de 1 centavo ao expoente público 3 em um sistema RSA, o valor de 2 centavos ao expoente 5, 4 centavos ao expoente 7 e assim por diante; cada valor sucessivo de potência-de-dois é representado pelo correspondente expoente público ímpar correspondente, todos com o mesmo módulo. Assim como em [C89], uma terceira raiz de uma imagem sob a função unidirecional f (juntamente com o módulo de pré-imagem do composto RSA do banco) vale 1 centavo, uma raiz 7 vale 4 centavos e uma raiz 21 5 centavos. Em outras palavras, um expoente primário público distinto é associado a cada dígito da representação inteira binária de uma quantia de pagamento; para uma determinada quantia de pagamento, o produto de todos aqueles expoentes principais correspondentes a 1 '
   </p>
 
   <p>
-    Three online schemes are presented here. Each relies on the same techniques for encoding denominations in signatures and for "devaluing" signatures to the exact amount chosen at the time of payment. They differ in how the unspent value is returned to the payer. In the first, all change is accumulated by the payer in a single "cookie jar," which might be deposited at the bank during the next withdrawal transaction. The second and third schemes allow change to be distributed among unspent notes, which can themselves later be spent. The second scheme reveals to the shop and bank the maximum amount for which a note can be spent; the third does not disclose this information.
-  </p>
-
-  <h3>Denominations and devaluing</h3>
-
-  <p>
-    For simplicity and concreteness, but without loss of generality, a particular denomination scheme will be used here. It assigns the value of 1 cent to public exponent 3 in an RSA system, the value of 2 cents to exponent 5, 4 cents to exponent 7, and so on; each successive power-of-two value is represented by the corresponding odd prime public exponent, all with the same modulus. Much as in [C89], a third root of an image under the one-way function f (together with the pre-image modulo the bank's RSA composite) is worth 1 cent, a 7th root is worth 4 cents, and a 21st root 5 cents. In other words, a distinct public prime exponent is associated with each digit of the binary integer representation of an amount of payment; for a particular amount of payment, the product of all those prime exponents corresponding to 1 's in the binary representation of the amount is the public exponent of the signature.
+    Uma assinatura em uma imagem sob f é "desvalorizada", elevando-a aos poderes públicos correspondentes aos valores de moeda que devem ser removidos. Por exemplo, uma nota com uma raiz de 21 pode ser desvalorizada do seu valor de 5 cêntimos para 1 cêntimo, simplesmente aumentando-a para a 7ª potência.
   </p>
 
   <p>
-    A signature on an image under f is "devalued" by raising it to the public powers corresponding to the coin values that should be removed. For instance, a note having a 21st root could be devalued from its 5 cent value, to 1 cent, simply by raising it to the 7th power.
+    Nos sistemas de pagamento on-line anteriores<sup><a href="#fnC89" id="refC89-2">[C89]</a></sup>, o número de assinaturas separadas necessárias para um pagamento era, em geral, o peso de Hamming da representação binária do valor. Como os sistemas on-line seriam usados ​​para pagamentos de valor mais alto (como mencionado acima), e uma resolução extra pode ser desejada para fornecer juros para fundos não gastos<sup><a href="#fnC89" id="refC89-3">[C89]</a></sup>, uma média de aproximadamente uma ordem de magnitude é salva aqui.
   </p>
 
-  <p>
-    In earlier online payment systems<sup><a href="#fnC89" id="refC89-2">[C89]</a></sup>, the number of separate signatures needed for a payment was in general the Hamming weight of the binary representation of the amount. Since online systems would be used for higher-value payments (as mentioned above), and extra resolution may be desired to provide interest for unspent funds<sup><a href="#fnC89" id="refC89-3">[C89]</a></sup>, an average of roughly an order of magnitude is saved here.
-  </p>
-
-  <h3>Cookie jar</h3>
+  <h3>Pote de biscoitos</h3>
 
   <p>
-    In this first scheme the payer periodically withdraws a supply of notes from the bank, each with the system-wide maximum value. Consider an example, shown in Figure 1.1, in which two notes are withdrawn. The n and ri are random. The ri "blind" (from the bank) the images under the public, one-way function f. The bank's signature corresponds to taking the h-th root, where h = 3*5*7*11. As in all the figures, the payer sends messages from the left and the bank sends from the right.
+    Neste primeiro esquema, o pagador retira periodicamente uma oferta de notas do banco, cada uma com o valor máximo para todo o sistema. Considere um exemplo, mostrado na Figura 1.1, no qual duas notas são retiradas. N e ri são aleatórios. O ri "cego" (do banco) as imagens sob a função pública, unidirecional f. A assinatura do banco corresponde à raiz h-ésima, onde h = 3 * 5 * 7 * 11. Como em todos os números, o pagador envia mensagens da esquerda e o banco envia da direita.
   </p>
 
 <pre>
                     h             h
           f(n1) * r1 ,  f(n2) * r2
      -----------------------------------------&gt;
-PAYER                                        BANK
+PAGADOR                                        BANCO
      &lt;------------------------------------------
                1/h            1/h
           f(n1)    * r1, f(n2)    * r2
 
-           Fig. 1.1. Cookie-jar withdrawal
+           Fig. 1.1. Retirada do pote de biscoitos
 </pre>
 
   <p>
-    In preparing the first payment, the payer divides r1 out. The signature is then raised to the 55th power to devalue it from 15 cents to 5 cents. Figure 1.2 shows this first payment. Of course the shop is an intermediary between the payer (left) and the bank (right) in every online payment, but this is not indicated explicitly. Also not shown in the figures are messages used to agree on the amounts of payment.
+    Na preparação do primeiro pagamento, o pagador divide r1 out. A assinatura é então aumentada para a 55ª potência para desvalorizá-la de 15 centavos a 5 centavos. A figura 1.2 mostra esse primeiro pagamento. É claro que a loja é um intermediário entre o pagador (à esquerda) e o banco (à direita) em cada pagamento on-line, mas isso não é indicado explicitamente. Também não são mostrados nos números as mensagens usadas para concordar com os valores de pagamento.
   </p>
 
 <pre>
                    1/(3*7)           5*11
           n1, f(n1)       , f(j) * s1
      -----------------------------------------&gt;
-PAYER                                        BANK
+PAGADOR                                        BANCO
      &lt;------------------------------------------
               1/(5*11)
           f(j)         * s1
 
-           Fig. 1.2. First cookie-jar payment
+           Fig. 1.2. Primeiro pagamento pelo pote de biscoitos
 </pre>
 
   <p>
-    The first two residues sent in paying, n1 and its signed image under f, are easily verified by the bank to be worth 5 cents. The third residue is a blinded "cookie jar," a blinded image under f of a randomly chosen value j. This cookie jar is modulo a second RSA composite that is only used for cookie jars. Once the bank verifies the funds received, and that n1 has not been spent previously, it signs and returns the blinded cookie jar (under the cookie jar modulus) with public exponents corresponding to the change due.
+    Os dois primeiros resíduos enviados pagando, n1 e sua imagem assinada sob f, são facilmente verificados pelo banco valendo 5 centavos. O terceiro resíduo é um "cookie jar" cego, uma imagem cega sob f de um valor escolhido aleatoriamente j. Este cookie jar é modulo um segundo composto RSA que é usado apenas para jars de cookie. Uma vez que o banco verifique os fundos recebidos e que n1 não tenha sido gasto anteriormente, ele assina e retorna o frasco de cookie cegado (sob o módulo jar do cookie) com expoentes públicos correspondentes à alteração devida.
   </p>
 
   <p>
-    The second payment, shown in figure 1.3, is essentially the same as the first, except that the amount is 3 cents and the cookie jar now has some roots already on it. If more payments were to be made using the same cookie jar, all resulting signatures for change would accumulate.
+    O segundo pagamento, mostrado na figura 1.3, é essencialmente o mesmo que o primeiro, exceto que a quantia é de 3 centavos e o cookie jar agora tem algumas raízes. Se mais pagamentos fossem feitos usando o mesmo pote de biscoitos, todas as assinaturas resultantes para mudança se acumulariam.
   </p>
 
 <pre>
                    1/(3*5)      1/(5*11)    7*11
           n2, f(n2)       , f(j)        * s2
      -----------------------------------------&gt;
-PAYER                                        BANK
+PAGADOR                                        BANCO
      &lt;------------------------------------------
               1/(5*11*7*11)
           f(j)              * s2
 
-           Fig. 1.3. Second cookie-jar payment
+           Fig. 1.3. Segundo pagamento pelo pote de biscoitos
 </pre>
 
   <p>
-    The cookie jar might conveniently be deposited, as shown in figure 1.4, during the withdrawal of the next batch of notes. It is verified by the bank much as a payment note would be: the roots must be present in the claimed multiplicity and the pre-image under f must not have been deposited before.
+    O pode de biscoitos pode ser convenientemente depositado, como mostrado na figura 1.4, durante a retirada do próximo lote de notas. É verificado pelo banco como uma nota de pagamento seria: as raízes devem estar presentes na multiplicidade reivindicada e a pré-imagem em f não deve ter sido depositada antes.
   </p>
 
 <pre>
                  1/(5*7*11*11)
           j, f(j)
      -----------------------------------------&gt;
-PAYER                                        BANK
+PAGADOR                                        BANCO
 
-           Fig. 1.4. Cookie-jar deposit
+           Fig. 1.4. Depósito no pote de biscoitos
 </pre>
 
   <p>
-    The cookie jar approach gives the effect of an online form of "offline checks"<sup><a href="#fnC89" id="refC89-4">[C89]</a></sup>, in that notes of a fixed value are withdrawn and the unspent parts later credited to the payer during a refund transaction.
+    A abordagem do pode de biscoitos o efeito de um formulário on-line de "cheques off-line"<sup><a href="#fnC89" id="refC89-4">[C89]</a></sup>, em que as notas de um valor fixo são retiradas e as partes não gastas posteriormente creditadas ao pagador durante uma transação de reembolso.
   </p>
 
-  <h3>Declared note value</h3>
+  <h3>Valor da nota declarada</h3>
 
   <p>
-    Figure 2 depicts a somewhat different scheme, which allows change to be spent without an intervening withdrawal transaction. Withdrawals can be just as in the cookie-jar scheme, but here a single modulus is used for everything in the system. The products of public exponents representing the various amounts are as follows: d is the amount paid, g is the note value, the "change" c is g/d, and h is again the maximal amount, where d | g | h. A payment (still to the bank through a shop) includes first and second components that are the same as in the cookie-jar scheme. The third component is the amount of change c the payer claims should be returned. The fourth is a (blinded) number m, which could be an image under f used in a later payment just as n is used in this one.
+    A Figura 2 descreve um esquema um pouco diferente, que permite que a mudança seja gasta sem uma transação de retirada intermediária. As retiradas podem ser exatamente como no esquema cookie-jar, mas aqui um único módulo é usado para tudo no sistema. Os produtos de exponentes públicos que representam os vários valores são os seguintes: d é o valor pago, g é o valor da nota, a "mudança" c é g / d e h é novamente a quantia máxima, onde d | g | h. Um pagamento (ainda para o banco através de uma loja) inclui primeiro e segundo componentes que são os mesmos que no esquema cookie-jar. O terceiro componente é a quantidade de mudança que o solicitante deve devolver. O quarto é um número (cego) m, que poderia ser uma imagem sob f usada em um pagamento posterior, assim como n é usado neste.
   </p>
 
 <pre>
                  1/d        c
           n, f(n)   , c, m*s
      -----------------------------------------&gt;
-PAYER                                        BANK
+PAGADOR                                        BANCO
      &lt;------------------------------------------
                      +------------+
-           1/c       |       1/c  | (Graphic padlock)
+           1/c       |       1/c  | (Cadeado gráfico)
           m    * s * | f(f(n)   ) |
                      +------------+
 
-           Fig. 2. Declared note value payment
+           Fig. 2. Pagamento do valor da nota declarada
 </pre>
 
   <p>
-    The signature returned contains a "protection" factor (shown inside the padlock). This factor ensures that the payer actually has the c-th root of f(n), by requiring that the payer apply f to it before dividing the result out of the signature. Without such protection, a payer could get the systemwide maximum change, regardless of how much change is actually due; with it, the change claimed can only be recovered if the corresponding roots on n are in fact known to the payer.
+    A assinatura retornada contém um fator de "proteção" (mostrado dentro do cadeado). Esse fator garante que o pagador realmente tenha a c-ésima raiz de f (n), exigindo que o pagador lhe aplique f antes de dividir o resultado da assinatura. Sem essa proteção, um pagador pode obter a mudança máxima em todo o sistema, independentemente da quantidade de mudança realmente devida; com isso, a mudança reivindicada só pode ser recuperada se as raízes correspondentes em n forem de fato conhecidas do pagador.
   </p>
 
-  <h3>Distributing change</h3>
+  <h3>Distribuição de mudança</h3>
 
   <p>
-    The change returned in a payment can be divided into parts that fill in missing denominations in notes not yet spent. Suppose, for example, that the last payment is spent with d = 5*11, c = 3*7, and that m is formed by the payer as shown in the first line of Figure 3.1. Then unblinding after the payment yields the a shown in the second line.
+    A alteração retornada em um pagamento pode ser dividida em partes que preenchem as denominações ausentes nas notas ainda não gastas. Suponha, por exemplo, que o último pagamento seja gasto com d = 5 * 11, c = 3 * 7 e que m seja formado pelo pagador conforme mostrado na primeira linha da Figura 3.1. Em seguida, desbloquear após o pagamento produz o a mostrado na segunda linha.
   </p>
 
   <p>
-    (Use === for "is equivalent to")
+    (Use === for "é equivalente a")
   </p>
 
 <pre>
@@ -160,11 +160,11 @@ PAYER                                        BANK
                      1/21
               a === m
 
-           Fig. 3.1. Form of change returned
+           Fig. 3.1. Forma de mudança retornada
 </pre>
 
   <p>
-    From a, the two roots shown in the last two lines of Figure 3.2 are readily computed. (This technique is easily extended to include any number of separate roots.) Thus the values unused in the last payment fill in roots missing in notes n1 and n2.
+    De a, as duas raízes mostradas nas duas últimas linhas da Figura 3.2 são prontamente calculadas. (Essa técnica é facilmente estendida para incluir qualquer número de raízes separadas.) Assim, os valores não utilizados no último pagamento preenchem as raízes ausentes nas notas n1 e n2.
   </p>
 
 <pre>
@@ -179,49 +179,49 @@ PAYER                                        BANK
           1/3              -1/7
      f(n2)    === a * f(n1)
 
-           Fig. 3.2. Distributing the change
+           Fig. 3.2. Distribuindo a mudança
 </pre>
 
   <p>
-    Because overpayment allows change to be returned in any chosen denominations (not shown), the payer has extra flexibility and is able to use all funds held. This also increases convenience by reducing the need for withdrawals.
+    Como o pagamento a maior permite que a mudança seja devolvida em quaisquer denominações escolhidas (não mostradas), o pagador tem flexibilidade extra e é capaz de usar todos os fundos retidos. Isso também aumenta a conveniência, reduzindo a necessidade de retiradas.
   </p>
 
-  <h3>Hidden note value</h3>
+  <h3>Valor da nota oculta</h3>
 
   <p>
-    Although the combination of the previous two subsections is quite workable, it may be desirable for the payer not to have to reveal c to the shop or the bank. Figure 4 shows a system allowing this. The payment message is just as in the declared note value protocol above, except that c is not sent. The protection factor (shown again in a lock) is also placed under the signature, but it is missing the extra f and is raised to a random power z chosen by the bank
+    Embora a combinação das duas subseções anteriores seja bastante viável, pode ser desejável que o pagador não tenha que revelar c à loja ou ao banco. A figura 4 mostra um sistema permitindo isso. A mensagem de pagamento é exatamente como no protocolo de valor de nota declarado acima, exceto que c não é enviado. O fator de proteção (mostrado novamente em uma trava) também é colocado sob a assinatura, mas falta o f extra e é elevado para uma potência aleatória z escolhida pelo banco
   </p>
 
 <pre>
                  1/d     c
           n, f(n)   , m*s
      -----------------------------------------&gt;
-PAYER                                        BANK
+PAGADOR                                        BANCO
      &lt;------------------------------------------
                         +----------+
            d/h    g/h   |     zd/h |
           m    * s    * | f(n)     |, z
                         +----------+
 
-           Fig. 4. Hidden note value payment
+           Fig. 4. Pagamento com valor de nota oculto
 </pre>
 
   <p>
-    If z were known to the payer before payment, then the payer could cheat by including f(n) in the third component; this would yield the payer the system-wide maximum change, even if none were due. Consider a single change exponent q. If z mod q is guessed correctly by a cheating payer, then the payer improperly gets the corresponding coin value. Thus the chance of successful cheating is 1/q. If, however, the divisors of h are chosen sufficiently large, quite practical security can be achieved. When the possibilities of distributing change and refunding are included, this scheme's privacy surpasses that of a coin system.
+    Se z fosse conhecido do pagador antes do pagamento, então o pagador poderia trapacear incluindo f (n) no terceiro componente; isso daria ao pagador a mudança máxima em todo o sistema, mesmo que nenhuma fosse devida. Considere um único expoente de mudança q. Se z mod q é adivinhado corretamente por um pagador de trapaça, então o pagador recebe indevidamente o valor da moeda correspondente. Assim, a chance de fazer batota bem sucedida é 1 / q. Se, no entanto, os divisores de h forem escolhidos suficientemente grandes, a segurança bastante prática pode ser alcançada. Quando as possibilidades de distribuição de troca e reembolso são incluídas, a privacidade desse esquema supera a de um sistema de moedas.
   </p>
 
-  <h3>Conclusion</h3>
+  <h3>Conclusão</h3>
 
   <p>
-    Combining online coins improves efficiency, use of funds, convenience, and privacy.
+    A combinação de moedas on-line melhora a eficiência, o uso de fundos, a conveniência e a privacidade.
   </p>
 
-  <h3>References</h3>
+  <h3>Referências</h3>
 
   <ol>
     <li id="fnC89">
       <p>
-        Chaum, D., "Privacy Protected Payments: Unconditional Payer and/or Payee Anonymity," in Smart Card 2000, North-Holland, 1989, pp. 69-92.&nbsp;<a href="#refC89-1">↩</a>&nbsp;<a href="#refC89-2">↩</a>&nbsp;<a href="#refC89-3">↩</a>&nbsp;<a href="#refC89-4">↩</a>
+        Chaum, D., "Privacy Protected Payments: Unconditional Payer and/or Payee Anonymity," in Smart Card 2000, North-Holland, 1989, páginas 69-92.&nbsp;<a href="#refC89-1">↩</a>&nbsp;<a href="#refC89-2">↩</a>&nbsp;<a href="#refC89-3">↩</a>&nbsp;<a href="#refC89-4">↩</a>
       </p>
     </li>
 

--- a/todo/pgp-web-of-trust-misconceptions.html
+++ b/todo/pgp-web-of-trust-misconceptions.html
@@ -4,55 +4,53 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
   <div class="page-header">
     <h1 class="text-center">
-      PGP Web of Trust Misconceptions<br><small>Hal Finney</small>
+      Equívocos de confiança no PGP Web<br><small>Hal Finney</small>
     </h1>
     <h4 class="text-center">
-      March 30, 1994
+      30 de Março de 1994
     </h4>
   </div>
   <p>
-    One of the key concepts widely used to describe PGP is the "web of trust". This brings to mind a network of connections between people who know and communicate with each other. Two people who want to communicate can do so securely if there is a path of connections in the form of signed keys that joins them.
+    Um dos principais conceitos amplamente usados ​​para descrever o PGP é a "rede de confiança". Isso traz à mente uma rede de conexões entre pessoas que conhecem e se comunicam umas com as outras. Duas pessoas que querem se comunicar podem fazê-lo com segurança se houver um caminho de conexões na forma de chaves assinadas que as unam.
+	</p>
+
+  <p>
+    Mas isso não está certo. O fato fundamental sobre as assinaturas de chaves do PGP, que muitas vezes é mal entendido, é o seguinte:
   </p>
 
   <p>
-    But this is not quite right. The fundamental fact about PGP key signatures, which is often misunderstood, is this:
+    Você só pode se comunicar com segurança com alguém cuja chave é assinada por uma pessoa que você conhece, pessoalmente ou por reputação.
   </p>
 
   <p>
-    You can only communicate securely with someone whose key is signed by a person you know, either personally or by reputation.
+    Em outras palavras, se eu quiser me comunicar com joe@abc.com, só posso fazê-lo se um dos signatários de sua chave for uma pessoa que conheço. Se não, não tenho como julgar a validade de sua chave.
   </p>
 
   <p>
-    In other words, if I want to communicate with joe@abc.com, I can only do so if one of the signators of his key is a person I know. If not, I have no way of judging the validity of his key.
+    Isso desmente interpretações simples da "teia da confiança". Eu posso ter assinado a chave de A, A assinou B, B assinou C, C assinou D e D assinou Joe, mas isso não tem valor a menos que eu saiba D. Só então posso confiar na chave de Joe.
   </p>
 
   <p>
-    This belies simple interpretations of the "web of trust". I may have signed A's key, A has signed B's, B has signed C's, C has signed D's, and D has signed Joe's, but this is of no value unless I know D. Only then can I trust Joe's key.
+    Isso significa que, na imagem "web", só posso me comunicar com segurança com pessoas que estão no máximo dois saltos na rede de conexões. Eu posso me comunicar com as pessoas que conheço e posso me comunicar com as pessoas que elas conhecem, e é isso.
   </p>
 
   <p>
-    This means that, in the "web" picture, I can only communicate securely with people who are at most two hops away in the web of connections. I can communicate with the people I know, and I can communicate with the people they know, and that is it.
+    Isso é lamentável, porque o modelo da web simples se liga a alguma pesquisa famosa que sugere que quaisquer duas pessoas escolhidas aleatoriamente estão a apenas meia dúzia de passos de distância na rede de conexões quem-sabe-quem. (Este resultado de onde vem título do filme "Six Degrees of Separation"). Se você tivesse um sistema que realmente suportasse comunicações via tal modelo web, ele realmente teria a esperança de deixar duas pessoas se comunicarem que não tivessem um cadeia muito longa entre eles. Mas o PGP, com um comprimento máximo de cadeia de dois, não permitirá isso.  </p>
+  <p>
+    O que teria que ser adicionado para permitir que um verdadeiro modelo de web de confiança fosse usado em um programa como o PGP? Basicamente, o que é necessário é uma maneira de julgar a confiabilidade das assinaturas de pessoas que você não conhece. Isso seria mais plausivelmente fornecido pelas pessoas que assinaram as chaves. Por exemplo, se houvesse outro tipo de assinatura de chave que não apenas atestasse a identidade da pessoa, mas também sua confiabilidade e cuidado ao assinar chaves, uma cadeia de assinaturas poderia servir de base para uma verdadeira teia de confiança. Obviamente, tais assinaturas não poderiam ser distribuídas com a mesma facilidade com que temos agora, onde uma olhada na carteira de motorista de um estranho é sempre o que recebemos, mas elas podem ser dadas a amigos próximos e àqueles que conhecemos e confiamos.
   </p>
 
   <p>
-    This is unfortunate, because the simple web model ties into some famous research which suggests that any two people chosen at random are only about half a dozen steps apart in the web of who-knows-whom connections. (This result is where the title of the movie "Six Degrees of Separation" comes from.) If you had a system which actually supported communications via such a web model, it actually would have hope of letting two people communicate who did not have a very long chain between them. But PGP, with a maximum chain length of two, will not allow this.
+    Sistemas mais elaborados podem incluir classificações numéricas de confiabilidade que ajudariam a estimar a força de qualquer caminho dado. O ponto principal é que algumas informações desse tipo seriam necessárias para permitir a comunicação com pessoas distantes na rede de conexões.
   </p>
 
   <p>
-    What would have to be added in order to allow a true web of trust model to be used in a program like PGP? Basically what is needed is some way to judge the trustworthyness of signatures by people you don't know. This would most plausibly be provided by the people who had signed their keys. For example, if there were another type of key signature which did not only vouch for the person's identity, but also for his trustworthyness and care in signing keys, then a chain of such signatures could serve as the basis for a true web of trust. Obviously such signatures could not be given out nearly as easily as the kind we have now, where a glance at some stranger's drivers' licence is often all we get, but they could be given to close friends and those we know and trust.
+    Sem isso, acho que continuaremos a ter problemas com o PGP não sendo possível validar chaves de pessoas com as quais queremos nos comunicar. As pessoas coletarão enormes listas de assinaturas, na esperança de que quem quiser se comunicar com elas conheça uma dessas pessoas. Os validadores de chave centralizada aparecerão (como no caso do serviço SLED que está sendo iniciado agora, que assinará uma chave com base em uma verificação assinada com seu nome). O resultado pode ser uma escolha entre usar uma chave não assinada ou usar uma assinada por alguma burocracia sem rosto, o que não é melhor do que a concepção original do PEM.
   </p>
 
   <p>
-    More elaborate systems might include numerical ratings of trustworthiness which would help to estimate the strength of any given path. The main point is that some information of this kind would be needed in order to allow communication with people distant in the web of connections.
-  </p>
-
-  <p>
-    Without this, I think we will continue to have problems with PGP being unable to validate keys of people we want to communicate with. People will collect huge laundry lists of signatures in the hopes that whoever wants to communicate with them will know one of those people. Centralized key validators will appear (as in the case of the SLED service being started now, which will sign a key based on a signed check with your name on it). The result may be a choice between using an unsigned key or using one signed by some faceless bureaucracy, which is no better than the original PEM conception.
-  </p>
-
-  <p>
-    (People may be confused by this essay because they thought PGP worked this way already. PGP does have a follow-the-web model, but that is only for following signatures. In the example above, where I wanted to talk to Joe and there was a chain to him through A, B, C, and D, we have to first suppose that I know and trust all of A, B, C, and D. Given that, what PGP can do is to determine whether I have valid keys for all of those people. It will notice that A has signed B's key, so it is valid. I know B and told PGP he was trustworthy, and he signed C's key, so therefore that one is valid. Similarly, I know C and I know D so PGP can follow the chain through them. Finally we come to Joe, whom I don't know, but because I know D and PGP followed the web to determine that D's key is valid, PGP can determine that Joe's key is valid. But again, that was only because I knew D and everyone else in the chain. The bottom line is still that I can only communicate with people who know someone I know.)
-  </p>
+    (As pessoas podem ficar confusas com este ensaio porque achavam que o PGP já funcionava dessa maneira. O PGP tem um modelo de acompanhamento, mas isso é apenas para acompanhar assinaturas. No exemplo acima, onde eu queria falar com Joe e lá foi uma cadeia para ele através de A, B, C e D, temos que primeiro supor que eu conheço e confio em todos os A, B, C e D. Dado que, o que o PGP pode fazer é determinar se eu tenho chaves para todas essas pessoas.Ele notará que A assinou a chave de B, por isso é válido.Eu sei B e disse PGP ele era confiável, e ele assinou a chave de C, portanto, que um é válido.Além disso, eu sei C e eu conheço D para que o PGP possa seguir a cadeia através deles.Finalmente chegamos a Joe, a quem eu não sei, mas como sei que D e PGP seguiram a web para determinar que a chave de D é válida, o PGP pode determinar que a chave de Joe É válido, mas, novamente, isso foi apenas porque eu conhecia D e todos os demais da cadeia.O ponto principal é que eu só posso me comunicar com pessoas que conheçam alguém que conheço. )
+	</p>
 
   <p>
     Hal Finney<br>
@@ -60,7 +58,7 @@
   </p>
 
   <p>
-    <a href="http://finney.org/~hal/">Hal Finney Home Page</a>
+    <a href="http://finney.org/~hal/">Página de Hal Finney</a>
   </p>
 
 </div>

--- a/todo/right-to-read.html
+++ b/todo/right-to-read.html
@@ -4,227 +4,204 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
   <div class="page-header">
     <h1 class="text-center">
-      The Right to Read <br><small>Richard Stallman</small>
+      O direito de ler <br><small>Richard Stallman</small>
     </h1>
     <h4 class="text-center">
-      Originally published in 1996<br>
+      Originalmente publicado em 1996<br>
     </h4>
   </div>
 
     <p>
-        <em>From The Road to Tycho, a collection of articles about the antecedents of the Lunarian Revolution, published in Luna City in 2096.</em>
+        <em>Tirado de "The Road to Tycho", uma coletânea de artigos sobre os antecedentes da Revolução Lunariana, publicada em Luna City em 2096.</em>
     </p>
 
     <p>
-        For Dan Halbert, the road to Tycho began in college&mdash;when Lissa Lenz asked to borrow his computer. Hers had broken down, and unless she could borrow another, she would fail her midterm project. There was no one she dared ask, except Dan.
+        Para Dan Halbert, a estrada para Tycho começou na faculdade - quando Lissa Lenz pediu emprestado seu computador. Ela tinha quebrado, e a menos que ela pudesse emprestar outra, ela falharia em seu projeto de meio de mandato. Não havia ninguém que ela ousasse perguntar, exceto Dan.
     </p>
 
     <p>
-        This put Dan in a dilemma. He had to help her&mdash;but if he lent her his computer, she might read his books. Aside from the fact that you could go to prison for many years for letting someone else read your books, the very idea shocked him at first. Like everyone, he had been taught since elementary school that sharing books was nasty and wrong&mdash;something that only pirates would do.
+        Isso colocou Dan em um dilema. Ele tinha que ajudá-la, mas se ele emprestasse seu computador, ela poderia ler seus livros. Além do fato de que você poderia ir para a prisão por muitos anos por deixar alguém ler seus livros, a própria idéia o chocou a princípio. Como todos, ele aprendera desde a escola primária que compartilhar livros era desagradável e errado - algo que apenas os piratas fariam.
     </p>
 
     <p>
-        And there wasn't much chance that the SPA&mdash;the Software Protection Authority&mdash;would fail to catch him. In his software class, Dan had learned that each book had a copyright monitor that reported when and where it was read, and by whom, to Central Licensing. (They used this information to catch reading pirates, but also to sell personal interest profiles to retailers.) The next time his computer was networked, Central Licensing would find out. He, as computer owner, would receive the harshest punishment&mdash;for not taking pains to prevent the crime.
+        E não havia muita chance de que a SPA - a Autoridade de Proteção de Software - falhasse em pegá-lo. Em sua aula de software, Dan sabia que cada livro tinha um monitor de direitos autorais que informava quando e onde era lido e por quem, para o Licenciamento Central. (Eles usaram essa informação para capturar piratas lidos, mas também para vender perfis de interesse pessoal para varejistas.) Na próxima vez em que seu computador estivesse em rede, a Central Licensing descobriria. Ele, como proprietário do computador, receberia o castigo mais severo - por não se esforçar para evitar o crime.
     </p>
 
     <p>
-        Of course, Lissa did not necessarily intend to read his books. She might want the computer only to write her midterm. But Dan knew she came from a middle-class family and could hardly afford the tuition, let alone her reading fees. Reading his books might be the only way she could graduate. He understood this situation; he himself had had to borrow to pay for all the research papers he read. (Ten percent of those fees went to the researchers who wrote the papers; since Dan aimed for an academic career, he could hope that his own research papers, if frequently referenced, would bring in enough to repay this loan.)
+        Obviamente Lissa não pretendia necessariamente ler seus livros. Ela pode querer que o computador apenas a escreva no meio do caminho. Mas Dan sabia que ela vinha de uma família de classe média e não podia pagar as mensalidades, muito menos as taxas de leitura. Lendo seus livros pode ser a única maneira que ela poderia se formar. Ele entendeu essa situação; ele mesmo teve que pedir emprestado para pagar todos os documentos de pesquisa que leu. (Dez por cento dessas taxas foram para os pesquisadores que escreveram os artigos; desde que Dan visava uma carreira acadêmica, ele podia esperar que seus próprios documentos de pesquisa, se frequentemente referenciados, trouxessem o suficiente para pagar esse empréstimo.)
     </p>
 
     <p>
-        Later on, Dan would learn there was a time when anyone could go to the library and read journal articles, and even books, without having to pay. There were independent scholars who read thousands of pages without government library grants. But in the 1990s, both commercial and nonprofit journal publishers had begun charging fees for access. By 2047, libraries offering free public access to scholarly literature were a dim memory.
+        Mais tarde, Dan ficaria sabendo que havia uma época em que alguém poderia ir à biblioteca e ler artigos de periódicos e até livros, sem ter que pagar. Havia estudiosos independentes que liam milhares de páginas sem subvenções da biblioteca do governo. Mas na década de 1990, tanto os editores de revistas comerciais quanto os sem fins lucrativos começaram a cobrar taxas pelo acesso. Em 2047, as bibliotecas que ofereciam acesso público gratuito à literatura acadêmica eram uma memória fraca.
     </p>
 
     <p>
-        There were ways, of course, to get around the SPA and Central Licensing. They were themselves illegal. Dan had had a classmate in software, Frank Martucci, who had obtained an illicit debugging tool, and used it to skip over the copyright monitor code when reading books. But he had told too many friends about it, and one of them turned him in to the SPA for a reward (students deep in debt were easily tempted into betrayal). In 2047, Frank was in prison, not for pirate reading, but for possessing a debugger.
+        Havia maneiras, claro, de contornar o SPA e o Licenciamento Central. Eles eram eles mesmos ilegais. Dan tinha tido um colega de turma em software, Frank Martucci, que havia obtido uma ferramenta de depuração ilícita, e a usava para pular o código do monitor de direitos autorais ao ler livros. Mas ele contara a muitos amigos sobre o assunto, e um deles o entregou ao SPA por uma recompensa (estudantes profundamente endividados foram facilmente tentados a traí-lo). Em 2047, Frank estava na prisão, não por leitura de piratas, mas por possuir um depurador.
     </p>
 
     <p>
-        Dan would later learn that there was a time when anyone could have debugging tools. There were even free debugging tools available on CD or downloadable over the net. But ordinary users started using them to bypass copyright monitors, and eventually a judge ruled that this had become their principal use in actual practice. This meant they were illegal; the debuggers' developers were sent to prison.
+		Dan aprenderia mais tarde que houve um tempo em que alguém poderia ter ferramentas de depuração. Havia até mesmo ferramentas de depuração gratuitas disponíveis em CD ou descarregáveis ​​na rede. Mas os usuários comuns começaram a usá-los para ignorar os monitores de direitos autorais e, eventualmente, um juiz decidiu que isso se tornara seu principal uso na prática real. Isso significava que eles eram ilegais; os desenvolvedores dos depuradores foram enviados para a prisão.
     </p>
 
     <p>
-        Programmers still needed debugging tools, of course, but debugger vendors in 2047 distributed numbered copies only, and only to officially licensed and bonded programmers. The debugger Dan used in software class was kept behind a special firewall so that it could be used only for class exercises.
+		Os programadores ainda precisavam de ferramentas de depuração, é claro, mas os fornecedores de depuradores em 2047 apenas distribuíam cópias numeradas e apenas para programadores oficialmente licenciados e vinculados. O depurador Dan usado na classe de software foi mantido atrás de um firewall especial para que pudesse ser usado apenas para exercícios de classe.
     </p>
 
     <p>
-        It was also possible to bypass the copyright monitors by installing a modified system kernel. Dan would eventually find out about the free kernels, even entire free operating systems, that had existed around the turn of the century. But not only were they illegal, like debuggers&mdash;you could not install one if you had one, without knowing your computer's root password. And neither the FBI nor Microsoft Support would tell you that.
+        Também foi possível ignorar os monitores de direitos autorais instalando um kernel do sistema modificado. Dan acabaria descobrindo sobre os núcleos gratuitos, até mesmo os sistemas operacionais livres, que existiam por volta da virada do século. Mas eles não eram apenas ilegais, como depuradores - você não podia instalar um se tivesse um, sem saber a senha de root do seu computador. E nem o FBI nem o Suporte da Microsoft lhe diriam isso.
     </p>
 
     <p>
-        Dan concluded that he couldn't simply lend Lissa his computer. But he couldn't refuse to help her, because he loved her. Every chance to speak with her filled him with delight. And that she chose him to ask for help, that could mean she loved him too.
+        Dan concluiu que ele não poderia simplesmente emprestar a Lissa seu computador. Mas ele não podia se recusar a ajudá-la, porque ele a amava. Toda chance de falar com ela o encheu de prazer. E que ela o escolheu para pedir ajuda, isso poderia significar que ela também o amava.
     </p>
 
     <p>
-        Dan resolved the dilemma by doing something even more unthinkable&mdash;he lent her the computer, and told her his password. This way, if Lissa read his books, Central Licensing would think he was reading them. It was still a crime, but the SPA would not automatically find out about it. They would only find out if Lissa reported him.
+        Dan resolveu o dilema fazendo algo ainda mais impensável - ele emprestou-lhe o computador e disse-lhe sua senha. Dessa forma, se Lissa lesse seus livros, a Central Licensing pensaria que ele estava lendo. Ainda era um crime, mas o SPA não iria descobrir automaticamente sobre isso. Eles só descobririam se Lissa o denunciasse.
     </p>
 
     <p>
-        Of course, if the school ever found out that he had given Lissa his own password, it would be curtains for both of them as students, regardless of what she had used it for. School policy was that any interference with their means of monitoring students' computer use was grounds for disciplinary action. It didn't matter whether you did anything harmful&mdash;the offense was making it hard for the administrators to check on you. They assumed this meant you were doing something else forbidden, and they did not need to know what it was.
+        É claro que, se a escola descobrisse que ele havia dado a Lissa sua própria senha, seriam cortinas para os dois como estudantes, independentemente do que ela tivesse usado. A política da escola era de que qualquer interferência em seus meios de monitorar o uso do computador pelos alunos era motivo para ação disciplinar. Não importava se você fez alguma coisa prejudicial - a ofensa estava dificultando a verificação dos administradores. Eles assumiram que isso significava que você estava fazendo outra coisa proibida, e eles não precisavam saber o que era.
     </p>
 
     <p>
-        Students were not usually expelled for this&mdash;not directly. Instead they were banned from the school computer systems, and would inevitably fail all their classes.
+        Os estudantes geralmente não eram expulsos por isso - não diretamente. Em vez disso, foram banidos dos sistemas de computadores da escola e inevitavelmente falhariam em todas as suas aulas.
     </p>
 
     <p>
-        Later, Dan would learn that this kind of university policy started only in the 1980s, when university students in large numbers began using computers. Previously, universities maintained a different approach to student discipline; they punished activities that were harmful, not those that merely raised suspicion.
+        Mais tarde, Dan aprenderia que esse tipo de política universitária começou apenas na década de 1980, quando estudantes universitários em grande número começaram a usar computadores. Anteriormente, as universidades mantinham uma abordagem diferente para a disciplina estudantil; puniam atividades nocivas, não aquelas que apenas levantavam suspeitas.
     </p>
 
     <p>
-        Lissa did not report Dan to the SPA. His decision to help her led to their marriage, and also led them to question what they had been taught about piracy as children. The couple began reading about the history of copyright, about the Soviet Union and its restrictions on copying, and even the original United States Constitution. They moved to Luna, where they found others who had likewise gravitated away from the long arm of the SPA. When the Tycho Uprising began in 2062, the universal right to read soon became one of its central aims.
+        Lissa não denunciou Dan ao SPA. Sua decisão de ajudá-la levou ao casamento e também levou-os a questionar o que aprenderam sobre a pirataria quando crianças. O casal começou a ler sobre a história dos direitos autorais, sobre a União Soviética e suas restrições à cópia, e até mesmo sobre a Constituição original dos Estados Unidos. Eles se mudaram para Luna, onde encontraram outros que também haviam se afastado do longo braço do SPA. Quando a revolta de Tycho começou em 2062, o direito universal de ler logo se tornou um de seus objetivos centrais.
     </p>
     
     <hr>
 
-    <h3>Author's Note</h3>
+    <h3>Nota do autor</h3>
 
     <p>
-        <em>This note has been updated several times since the first publication of the story.</em>
+        <em>Esta nota foi atualizada várias vezes desde a primeira publicação da história.</em>
     </p>
 
     <p>
-        The right to read is a battle being fought today. Although it may take 50 years for our present way of life to fade into obscurity, most of the specific laws and practices described above have already been proposed; many have been enacted into law in the US and elsewhere. In the US, the 1998 Digital Millennium Copyright Act (DMCA) established the legal basis to restrict the reading and lending of computerized books (and other works as well). The European Union imposed similar restrictions in a 2001 copyright directive. In France, under the DADVSI law adopted in 2006, mere possession of a copy of DeCSS, the free program to decrypt video on a DVD, is a crime.
+        O direito de ler é uma batalha que está sendo travada hoje. Embora possa levar 50 anos para que nosso modo de vida atual se desvanece na obscuridade, a maioria das leis e práticas específicas descritas acima já foram propostas; muitos foram promulgados como lei nos EUA e em outros lugares. Nos EUA, o Digital Millennium Copyright Act de 1998 (DMCA) estabeleceu a base legal para restringir a leitura e empréstimo de livros informatizados (e outros trabalhos também). A União Europeia impôs restrições semelhantes em uma diretiva de direitos autorais de 2001. Na França, de acordo com a lei DADVSI adotada em 2006, a mera posse de uma cópia do DeCSS, o programa gratuito para descriptografar um vídeo em um DVD, é um crime.
     </p>
 
     <p>
-        In 2001, Disney-funded Senator Hollings proposed a bill called the SSSCA that would require every new computer to have mandatory copy-restriction facilities that the user cannot bypass. Following the Clipper chip and similar US government key-escrow proposals, this shows a long-term trend: computer systems are increasingly set up to give absentees with clout control over the people actually using the computer system. The SSSCA was later renamed to the unpronounceable CBDTPA, which was glossed as the "Consume But Don't Try Programming Act."
+        Em 2001, o senador Hollings, financiado pela Disney, propôs um projeto de lei chamado SSSCA, que exigiria que cada novo computador tivesse instalações obrigatórias de restrição de cópias que o usuário não pode ignorar. Seguindo o chip Clipper e propostas semelhantes de cofres de chaves do governo dos EUA, isso mostra uma tendência de longo prazo: os sistemas de computador estão sendo cada vez mais configurados para dar aos ausentes controle sobre as pessoas que realmente usam o sistema de computador. O SSSCA foi depois renomeado para o impronunciável CBDTPA, que foi descrito como "Consumir, mas não tente programar".
     </p>
 
     <p>
-        The Republicans took control of the US senate shortly thereafter. They are less tied to Hollywood than the Democrats, so they did not press these proposals. Now that the Democrats are back in control, the danger is once again higher.
+        Os republicanos assumiram o controle do Senado dos EUA pouco depois. Eles estão menos ligados a Hollywood do que os democratas, então eles não pressionaram essas propostas. Agora que os democratas estão de volta ao controle, o perigo é mais uma vez maior.
     </p>
 
     <p>
-        In 2001 the US began attempting to use the proposed Free Trade Area of the Americas (FTAA) treaty to impose the same rules on all the countries in the Western Hemisphere. The FTAA is one of the so-called free trade treaties, which are actually designed to give business increased power over democratic governments; imposing laws like the DMCA is typical of this spirit. The FTAA was effectively killed by Lula, President of Brazil, who rejected the DMCA requirement and others.
+        Em 2001, os EUA começaram a tentar usar o Tratado de Área de Livre Comércio das Américas (ALCA) para impor as mesmas regras a todos os países do Hemisfério Ocidental. A ALCA é um dos chamados tratados de livre comércio, que na verdade são destinados a dar aos negócios maior poder sobre os governos democráticos; impor leis como a DMCA é típico desse espírito. A Alca foi efetivamente morta por Lula, presidente do Brasil, que rejeitou a exigência da DMCA e outros.
     </p>
 
     <p>
-        Since then, the US has imposed similar requirements on countries such as Australia and Mexico through bilateral "free trade" agreements, and on countries such as Costa Rica through another treaty, CAFTA. Ecuador's President Correa refused to sign a "free trade" agreement with the US, but I've heard Ecuador had adopted something like the DMCA in 2003.
+       Desde então, os EUA impuseram exigências semelhantes em países como a Austrália e o México por meio de acordos bilaterais de "livre comércio", e em países como a Costa Rica por meio de outro tratado, o CAFTA. O presidente do Equador, Correa, se recusou a assinar um acordo de "livre comércio" com os EUA, mas eu ouvi que o Equador adotou algo como o DMCA em 2003.
     </p>
 
     <p>
-        One of the ideas in the story was not proposed in reality until 2002. This is the idea that the FBI and Microsoft will keep the root passwords for your personal computers, and not let you have them.
+        Uma das idéias da história não foi proposta na realidade até 2002. Essa é a idéia de que o FBI e a Microsoft manterão as senhas de raiz dos seus computadores pessoais, e não permitirão que você as tenha.
     </p>
 
     <p>
-        The proponents of this scheme have given it names such as "trusted computing" and "Palladium." We call it <a href="https://www.gnu.org/philosophy/can-you-trust.html">treacherous computing"</a> because the effect is to make your computer obey companies even to the extent of disobeying and defying you. This was implemented in 2007 as part of <a href="http://badvista.org/">Windows Vista</a>; we expect Apple to do something similar. In this scheme, it is the manufacturer that keeps the secret code, but the FBI would have little trouble getting it.
+        Os proponentes desse esquema deram nomes como "computação confiável" e "paládio". Chamamos isso de <a href="https://www.gnu.org/philosophy/can-you-trust.html">"computação traiçoeira"</a> porque o efeito é fazer com que o seu computador obedeça às empresas, até mesmo ao ponto de desobedecer e desafiar você. Isso foi implementado em 2007 como parte do <a href="http://badvista.org/">Windows Vista</a>; esperamos que a Apple faça algo semelhante. Nesse esquema, é o fabricante que mantém o código secreto, mas o FBI não teria dificuldade em consegui-lo.
     </p>
 
     <p>
-        What Microsoft keeps is not exactly a password in the traditional sense; no person ever types it on a terminal. Rather, it is a signature and encryption key that corresponds to a second key stored in your computer. This enables Microsoft, and potentially any web sites that cooperate with Microsoft, the ultimate control over what the user can do on his own computer.
+        O que a Microsoft guarda não é exatamente uma senha no sentido tradicional; Ninguém nunca digita em um terminal. Pelo contrário, é uma chave de assinatura e criptografia que corresponde a uma segunda chave armazenada em seu computador. Isso permite que a Microsoft e, potencialmente, quaisquer sites da Web que cooperem com a Microsoft tenham o controle total sobre o que o usuário pode fazer em seu próprio computador.
     </p>
 
     <p>
-        Vista also gives Microsoft additional powers; for instance, Microsoft can forcibly install upgrades, and it can order all machines running Vista to refuse to run a certain device driver. The main purpose of Vista's many restrictions is to impose DRM (Digital Restrictions Management) that users can't overcome. The threat of DRM is why we have established the <a href="http://defectivebydesign.org/">Defective by Design</a> campaign.
+        O Vista também oferece poderes adicionais à Microsoft; por exemplo, a Microsoft pode forçar a instalação de atualizações e pode ordenar que todas as máquinas que executam o Vista se recusem a executar um determinado driver de dispositivo. O principal objetivo das muitas restrições do Vista é impor DRM (Digital Restrictions Management) que os usuários não podem superar. A ameaça do DRM é porque estabelecemos a campanha <a href="http://defectivebydesign.org/">Defective by Design</a>.
     </p>
 
     <p>
-        When this story was first written, the SPA was threatening small Internet service providers, demanding they permit the SPA to monitor all users. Most ISPs surrendered when threatened, because they cannot afford to fight back in court. One ISP, Community ConneXion in Oakland, California, refused the demand and was actually sued. The SPA later dropped the suit, but obtained the DMCA, which gave them the power they sought.
+        Quando essa história foi escrita pela primeira vez, o SPA estava ameaçando os pequenos provedores de serviços de Internet, exigindo que eles permitissem que o SPA monitorasse todos os usuários. A maioria dos ISPs se rendeu quando ameaçada, porque eles não podem se dar ao luxo de lutar no tribunal. Um ISP, Community ConneXion em Oakland, Califórnia, recusou a demanda e foi realmente processado. O SPA mais tarde desistiu do processo, mas obteve o DMCA, que lhes deu o poder que procuravam.
     </p>
 
     <p>
-        The SPA, which actually stands for Software Publishers Association, has been replaced in its police-like role by the Business Software Alliance. The BSA is not, today, an official police force; unofficially, it acts like one. Using methods reminiscent of the erstwhile Soviet Union, it invites people to inform on their coworkers and friends. A BSA terror campaign in Argentina in 2001 made slightly veiled threats that people sharing software would be raped.
+        O SPA, que na verdade significa Associação de editores de software, foi substituído em sua função de polícia pela Business Software Alliance. A BSA não é, hoje, uma força policial oficial; não oficialmente, age como um. Usando métodos reminiscentes da antiga União Soviética, ela convida as pessoas a informar seus colegas de trabalho e amigos. Uma campanha terrorista da BSA na Argentina em 2001 fez ameaças levemente veladas de que pessoas que compartilham software seriam estupradas.
     </p>
 
     <p>
-        The university security policies described above are not imaginary. For example, a computer at one Chicago-area university displayed this message upon login:
+        As políticas de segurança da universidade descritas acima não são imaginárias. Por exemplo, um computador em uma universidade da região de Chicago exibe essa mensagem no login:
     </p>
 
     <blockquote>
-        This system is for the use of authorized users only. Individuals
-        using this computer system without authority or in the excess of their
-        authority are subject to having all their activities on this system
-        monitored and recorded by system personnel. In the course of monitoring
-        individuals improperly using this system or in the course of system
-        maintenance, the activities of authorized user may also be monitored.
-        Anyone using this system expressly consents to such monitoring and is
-        advised that if such monitoring reveals possible evidence of illegal
-        activity or violation of University regulations system personnel may
-        provide the evidence of such monitoring to University authorities
-        and/or law enforcement officials.
+        Este sistema é para uso apenas de usuários autorizados. Indivíduos usando este sistema de computador sem autoridade ou em excesso de sua autoridade estão sujeitos a ter todas as suas atividades neste sistema monitoradas e registradas pelo pessoal do sistema. No decorrer do monitoramento de pessoas que usam indevidamente este sistema ou durante a manutenção do sistema, as atividades do usuário autorizado também podem ser monitoradas. Qualquer um que use este sistema consente expressamente com tal monitoramento e é aconselhado que, se tal monitoramento revelar possíveis evidências de atividade ilegal ou violação dos regulamentos da Universidade, o pessoal do sistema pode fornecer evidência de tal monitoramento para as autoridades da Universidade e / ou oficiais da lei.
     </blockquote>
 
     <p>
-        This is an interesting approach to the Fourth Amendment: pressure most everyone to agree, in advance, to waive their rights under it.
+        Esta é uma abordagem interessante para a Quarta Emenda: pressionar a maioria de todos a concordar, com antecedência, em renunciar a seus direitos sob ela.
     </p>
 
     <hr>
 
-    <h3>Bad News</h3>
+    <h3>Más notícias</h3>
 
     <p>
-        The battle for the right to read is already in progress. The enemy is organized, while we are not, so it is going against us. Here are articles about bad things that have happened since the original publication of this article.
+        A batalha pelo direito de ler já está em andamento. O inimigo é organizado, enquanto nós não somos, então está indo contra nós. Aqui estão os artigos sobre coisas ruins que aconteceram desde a publicação original deste artigo.
     </p>
 
     <ul>
-        <li>Today's commercial ebooks <a href=
-        "https://www.gnu.org/philosophy/the-danger-of-ebooks.html">abolish
-        readers' traditional freedoms.</a></li>
+        <li>Os ebooks comerciais de hoje <a href=
+        "https://www.gnu.org/philosophy/the-danger-of-ebooks.html">abolem as liberdades tradicionais dos leitores.</a></li>
 
-        <li><a href="http://www.nature.com/nature_education/biology.html">A
-        "biology textbook" web site</a> that you can access only by signing a
-        <a href="http://www.nature.com/principles/viewTermsOfUse">contract not
-        to lend it to anyone else</a>, which the publisher can revoke at
-        will.</li>
+        <li><a href="http://www.nature.com/nature_education/biology.html">Um site de biologia</a> que você pode acessar apenas assinando um
+        <a href="http://www.nature.com/principles/viewTermsOfUse">contrato para não emprestar a ninguém</a>, que o editor pode revogar à vontade.</li>
 
         <li><a href=
         "http://www.zdnet.com/news/seybold-opens-chapter-on-digital-books/103151">
-        Electronic Publishing:</a> An article about distribution of books in
-        electronic form, and copyright issues affecting the right to read a
-        copy.</li>
+        Publicação Eletrônica:</a> Um artigo sobre distribuição de livros em formato eletrônico e questões de direitos autorais que afetam o direito de ler uma cópia.</li>
 
         <li><a href=
-        "http://www.microsoft.com/en-us/news/press/1999/Aug99/SeyboldPR.aspx">Books
-        inside Computers:</a> Software to control who can read books and
-        documents on a PC.</li>
+        "http://www.microsoft.com/en-us/news/press/1999/Aug99/SeyboldPR.aspx">Livros dentro de computadores:</a> Software para controlar quem pode ler livros e documentos em um PC.</li>
     </ul>
 
     <p>
-        If we want to stop the bad news and create some good news, we need to organize and fight. The FSF's <a href="http://defectivebydesign.org/">Defective by Design</a> campaign has made a start &mdash; subscribe to the campaign's mailing list to lend a hand. And <a href="http://www.fsf.org/associate">join the FSF</a> to help fund our work.
+        Se quisermos parar as más notícias e criar boas notícias, precisamos nos organizar e lutar. A campanha <a href="http://defectivebydesign.org/">Defective by Design</a> da FSF começou - assine a lista de discussão da campanha para dar uma mãozinha. E <a href="http://www.fsf.org/associate">junte-se a FSF</a> para ajudar a financiar nosso trabalho.
     </p>
 
     <hr>
 
-    <h3>References</h3>
+    <h3>Referências</h3>
 
     <ul>
         <li>United States Patent and Trademark Office, <cite>Intellectual
         Property [<em>sic</em>] and the National Information Infrastructure:
         The Report of the Working Group on Intellectual Property [<em>sic</em>]
-        Rights,</cite> Washington, DC: GPO, 1995.</li>
+        Rights,</cite> Washington, DC: GPO de 1995.</li>
 
         <li>Samuelson, Pamela, <a href=
         "http://www.wired.com/wired/archive/4.01/white.paper_pr.html">"The
-        Copyright Grab,"</a> <em>Wired,</em> January 1996, n.&nbsp;4.01.</li>
+        Copyright Grab,"</a> <em>Wired,</em> Janeiro de 1996, n.&nbsp;4.01.</li>
 
         <li>Boyle, James, <a href=
         "http://www.law.duke.edu/boylesite/sold_out.htm">"Sold Out,"</a>
-        <em>New York Times,</em> 31&nbsp;March&nbsp;1996, sec.&nbsp;4,
+        <em>New York Times,</em> 31 de março de 1996, sec.&nbsp;4,
         p.&nbsp;15.</li>
 
         <li>Editorial, <em>Washington Post,</em> <a href=
         "http://web.archive.org/web/20130508120533/http://www.interesting-people.org/archives/interesting-people/199611/msg00012.html">
-        "Public Data or Private Data,"</a> 3&nbsp;November&nbsp;1996,
+        "Public Data or Private Data,"</a> 3 de novembro de 1996,
         sec.&nbsp;C, p.&nbsp;6.</li>
 
         <li><a href="http://www.public-domain.org/">Union for the Public
-        Domain</a>&mdash;an organization that aims to resist and reverse the
-        overextension of copyright and patent powers.</li>
+        Domain</a>&mdash;uma organização que visa resistir e reverter a superextensão de direitos autorais e patentes.</li>
     </ul>
 
     <hr>
 
-    <p>The <a href="http://www.fsf.org/">Free Software Foundation</a> is the
-    principal organizational sponsor of the <a href="http://www.gnu.org/">GNU
-    Operating System</a>. <strong>Their mission is to preserve, protect and
-    promote the freedom to use, study, copy, modify, and redistribute computer
-    software, and to defend the rights of Free Software users.</strong></p>
+    <p>A <a href="http://www.fsf.org/">Fundação do Software Livre</a> é o principal patrocinador organizacional do <a href="http://www.gnu.org/">Sistema Operacional GNU</a>. <strong>Sua missão é preservar, proteger e promover a liberdade de usar, estudar, copiar, modificar e redistribuir software de computador e defender os direitos dos usuários de Software Livre.</strong></p>
 
 
     <p>
-        Copyright &copy; 1996, 2002, 2007, 2009, 2010 Richard Stallman<br>
-        This essay was written in 1996 and was published in <cite>Communications of the ACM,</cite> vol.&nbsp;40, n.&nbsp;2, February 1997.
+        Direito Autoral &copy; 1996, 2002, 2007, 2009, 2010 Richard Stallman<br>
+        Este ensaio foi escrito em 1996 e foi publicado em <cite>Comunicações do ACM,</cite> vol.&nbsp;40, n.&nbsp;2, Fevereiro de 1997.
     </p>
 
 </div>

--- a/todo/the-god-protocols.html
+++ b/todo/the-god-protocols.html
@@ -5,55 +5,54 @@
 <div class="col-sm-6 col-sm-offset-3 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
   <div class="page-header">
     <h1 class="text-center">
-      The God Protocols <br><small>Nick Szabo</small>
+      Os protocolos de Deus <br><small>Nick Szabo</small>
     </h1>
     <h4 class="text-center">
-      Originally published in 1997<br>
+      Originalmente publicado em 1997<br>
     </h4>
   </div>
 		
   <p>
-    Imagine the ideal protocol.  It would have the most trustworthy third party imaginable &ndash; a diety who is on <em>everybody's</em> side. All the parties would send their inputs to God. God would reliably determine the results and return the outputs. God being the ultimate in confessional discretion, no party would learn anything more about the other parties' inputs than they could learn from their own inputs and the output.
+    Imagine o protocolo ideal. Ele teria a terceira parte mais confiável imaginável - uma entidade que está do lado de <em>todos</em>. Todas as partes enviariam suas contribuições para Deus. Deus determinaria confiavelmente os resultados e retornaria as saídas. Sendo Deus o supremo na discrição confessional, nenhuma das partes aprenderia mais sobre os insumos das outras partes do que eles poderiam aprender com seus próprios insumos e a saída.
   </p>
 
   <p>
-    Alas, in the our temporal world we deal with humans rather than deities. Yet, too often we are forced to treat people in a nearly theological manner, because our infrastructure lacks the security needed to protect ourselves.
+    Infelizmente, no nosso mundo temporal lidamos com humanos, em vez de divindades. No entanto, muitas vezes somos obrigados a tratar as pessoas de maneira quase teológica, porque nossa infra-estrutura carece da segurança necessária para nos proteger.
   </p>
 
-  <h2>Trusted Third Party</h2>
+  <h2>Terceiros confiáveis</h2>
 
   <img class="img-responsive center-block" src="/static/img/docs/the-god-protocols/mutually.gif">
 
   <p>
-    Network security theorists have recently solved this problem to an astonishing extent. They have developed protocols which create virtual machines between two or more parties. Multiparty secure computation allows any number of parties to share a computation, each learning only what can be inferred from their own inputs and the output of the computation. These virtual machines have the exciting property that each party's input is strongly confidential from the other parties. The program and the output are shared by the parties. 
+    Os teóricos de segurança de redes resolveram recentemente esse problema de maneira surpreendente. Eles desenvolveram protocolos que criam máquinas virtuais entre duas ou mais partes. A computação segura multipartidária permite que qualquer número de partes compartilhe uma computação, cada uma aprendendo apenas o que pode ser inferido a partir de suas próprias entradas e da saída da computação. Essas máquinas virtuais têm a interessante propriedade de que as informações de cada parte são altamente confidenciais das outras partes. O programa e a saída são compartilhados pelas partes.  
   </p>
-
   <p>
-    For example, we could run a spreadsheet across the Internet on this virtual computer. We would agree on a set of formulas and set up the virtual computer with these formulas. Each participant would have their own input cells, which remain blank on the other participants' computers. The participants share output cell(s). Each input our own private data into our input cells. Alice could only learn only as much about the other participants' input cells as she could infer from her own inputs and the output cells.
+    Por exemplo, poderíamos executar uma planilha na Internet neste computador virtual. Concordamos em um conjunto de fórmulas e configuramos o computador virtual com essas fórmulas. Cada participante teria suas próprias células de entrada, que permanecem em branco nos computadores dos outros participantes. Os participantes compartilham célula (s) de saída. Cada entrada nossos dados privados em nossas células de entrada. Alice só podia aprender tanto sobre as células de entrada dos outros participantes quanto poderia inferir a partir de suas próprias entradas e das células de saída.
   </p>
 
-  <h2>Mathematically Trustworthy Protocol</h2>
+  <h2>Protocolo Matematicamente Confiável</h2>
 
   <img class="img-responsive center-block" src="/static/img/docs/the-god-protocols/virtual.gif">
 
   <p>
-    There are three major limitations. The first is that this virtual computer is very slow: in some cases, one arithmetic calculation per network message. Currently it is at best practical only for small logic or arithmetic calculations used as an adjunct to or component of more efficient computations and protocols.   
+    Existem três grandes limitações. A primeira é que esse computador virtual é muito lento: em alguns casos, um cálculo aritmético por mensagem de rede. Atualmente, ele é, na melhor das hipóteses, prático apenas para lógica pequena ou cálculos aritméticos usados ​​como complemento ou componente de cálculos e protocolos mais eficientes.
+	</p>
+
+  <p>
+    A segunda é que existe uma troca entre privacidade, imparcialidade e tolerância a falhas. Equidade significa que todos aprendem os resultados de tal forma que ninguém pode obter vantagem aprendendo primeiro. A tolerância a falhas pode fornecer robustez contra uma minoria, de modo que é necessária uma maioria para interromper o protocolo ou pode ser não robusto, mas falha-parada, de modo que um único participante possa encerrar o protocolo. Muitos artigos discutiram a fração de partes em que alguém deve confiar para ter certeza de que aprenderá a saída correta. Nos resultados tradicionais, a imparcialidade e a privacidade não poderiam ser alcançadas com uma maioria defeituosa. Artigos recentes<sup><a href="#fn3" id="ref3">[3]</a></sup><sup><a href="#fn4" id="ref4">[4]</a></sup><sup><a href="#fn5" id="ref5">[5]</a></sup><sup><a href="#fn6" id="ref6">[6]</a></sup> produziram protocolos justos e privados, mesmo com maiorias defeituosas. Eles negociam robustez para privacidade e justiça contra qualquer proporção de partes defeituosas. A vantagem dessa abordagem fail-stop é que normalmente é possível encontrar novos parceiros e começar tudo de novo, mas não se quer sofrer perdas irreversíveis, como vazamento de informações, ficar segurando a bolsa ou estar convencido de um resultado incorreto.
   </p>
 
   <p>
-    The second is that there is a tradeoff between privacy, fairness, and fault tolerance. Fairness means everybody learning the results in such a way that nobody can gain an advantage by learning first. Fault tolerance can provide robustness against a minority, so that it takes a majority dropping out to halt the protocol, or it can be nonrobust but fail-stop, so that a single participant can terminate the protocol. Many papers have discussed the fraction of parties one must trust in order to be assured of learning the correct output. In traditional results, fairness and privacy could not both be achieved with a faulty majority. Recent papers<sup><a href="#fn3" id="ref3">[3]</a></sup><sup><a href="#fn4" id="ref4">[4]</a></sup><sup><a href="#fn5" id="ref5">[5]</a></sup><sup><a href="#fn6" id="ref6">[6]</a></sup> have produced fair and private protocols even with faulty majorities. They trade robustness for privacy and fairness against any proportion of faulty parties. The advantage of this fail-stop approach is that one can usually find new partners and start over again, but one does not want to suffer irreversible losses such as leaking information, being left holding the bag, or being convinced of an incorrect result.
+    A terceira limitação é que, longe de ser onisciente ou onipotente, o protocolo realizará apenas o que está especificado no algoritmo e nas entradas. Ele não poderá substituir terceiros confiáveis ​​onde essas partes fornecem informações ou conhecimentos que não podem ser fornecidos por um computador.
+	</p>
+
+  <p>
+	Com essas ressalvas, qualquer intermediário algorítmico pode, em princípio, ser substituído por um computador virtual confiável. Na prática, por causa das três complicações, geralmente construímos protocolos mais limitados a partir de elementos mais eficientes.
   </p>
 
   <p>
-    The third limitation is that, far from being omniscient or omnipotent, the protocol will accomplish only what is specified in the algorithm and the inputs. It won't be able to replace human trusted third parties where those parties provide insight or knowledge that cannot be provided by a computer.
-  </p>
-
-  <p>
-    With these caveats, any algorithmic intermediary can, in principle, be replaced by a trustworthy virtual computer. In practice, because of the three complications, we usually construct more limited protocols out of more efficient elements. 
-  </p>
-
-  <p>
-    Multiparty computation theory, by making possible privy virtual intermediation, has major implications, in theory, for all kinds of <a href="http://nakamotoinstitute.org/formalizing-securing-relationships.html">contractual relationships.</a> This can be seen most clearly in the area of negotiations. A "mechanism" in economics is an abstract model of an institution which communicates with its participants via messages, and whose rules can be specified algorithmically. These institutions can be auctions, exchanges, voting, and so on. They typically implement some kind of negotiation or decision making process. 
+    A teoria de computação multipartidária, ao possibilitar a intermediação virtual privada, tem implicações importantes, em teoria, para todos os tipos de <a href="http://nakamotoinstitute.org/formalizing-securing-relationships.html">relações contratuais.</a> Isso pode ser visto mais claramente na área de negociações. Um "mecanismo" na economia é um modelo abstrato de uma instituição que se comunica com seus participantes via mensagens e cujas regras podem ser especificadas por algoritmos. Essas instituições podem ser leilões, trocas, votação e assim por diante. Eles normalmente implementam algum tipo de negociação ou processo de tomada de decisão.
   </p>
 
   <!-- doesn't look like an auction...
@@ -61,42 +60,41 @@
   -->
 
   <p>
-    Economists assume a trusted intermediary operates the mechanism. Here's a simple example of using this virtual computer for a mechanism. Alice can submit a bid price, and Bob an ask price, then their shared virtual program which has one instruction, "A greater than B?". The computer then returns "true" if Alice's bid is greater than Bob's offer. A slightly more sophisticated computer may then decide the settlement price according to a number of different algorithms (Alice's bid, Bob's ask, split the difference, etc.) This implements the mechanism "blind bargaining" with no trusted intermediary. 
+    Economistas assumem que um intermediário de confiança opera o mecanismo. Aqui está um exemplo simples de usar este computador virtual para um mecanismo. Alice pode enviar um preço de compra, e Bob um preço de venda, depois o programa virtual compartilhado que tem uma instrução, "A maior que B?". O computador retorna "verdadeiro" se o lance de Alice for maior que a oferta de Bob. Um computador um pouco mais sofisticado pode então decidir o preço de acordo de acordo com um número de algoritmos diferentes (oferta de Alice, pergunta de Bob, divisão da diferença, etc.) Isso implementa o mecanismo "negociação cega" sem intermediário confiável.
   </p>
 
   <p>
-    In principle, since any computable problem can be solved on this virtual computer (they are "Turing complete"), any computable economic mechanism can be implemented without a trusted intermediary. In practice, we face the three limitations discussed above. But the existence proof, that any economic mechanism can be run without a trusted intermediary, is very exciting. This means that, in principle, any contract which can be negotiated through a trusted third party (such as an auction or exchange) can be negotiated directly. So, in some abstract sense, the only remaining "hard" problems in smart contract negotiations are (a) problems considered hard even with a trusted intermediary (for the standard economic reasons), and (b) the task of algorithmically specifying the negotiating rules and output contract terms (This includes cases where an intermediary adds knowledge unavailable to the participants, such as a lawyer giving advice on how to draft a contract). In practice, many problems which can be solved in principle with multiparty computation will re-arise when we implement protocols in an efficient, practical manner. The God Protocols give us a target to shoot for.
+    Em princípio, como qualquer problema computável pode ser resolvido neste computador virtual (eles são "Turing completos"), qualquer mecanismo econômico computável pode ser implementado sem um intermediário confiável. Na prática, enfrentamos as três limitações discutidas acima. Mas a prova da existência, de que qualquer mecanismo econômico pode ser executado sem um intermediário confiável, é muito emocionante. Isso significa que, em princípio, qualquer contrato que possa ser negociado por meio de um terceiro confiável (como um leilão ou troca) pode ser negociado diretamente. Assim, em algum sentido abstrato, os únicos problemas "difíceis" que restam nas negociações de contratos inteligentes são (a) problemas considerados difíceis mesmo com um intermediário de confiança (pelas razões econômicas padrão), e (b) a tarefa de especificar algoritmicamente as regras de negociação e os termos do contrato de produção (Isso inclui casos em que um intermediário adiciona conhecimento indisponível aos participantes, como um advogado dando conselhos sobre como redigir um contrato). Na prática, muitos problemas que podem ser resolvidos em princípio com computação multipartidária ressurgirão quando implementarmos protocolos de maneira eficiente e prática. Os Protocolos de Deus nos dão um alvo para atirar.
   </p>
 
   <p>
-    Applying this kind of analysis to the performance phase of contracts is less straightforward. For starters, economic theories of the performance phase are not as well developed or simple as the mechanism theory of negotiations. Indeed, most economic theory simply assumes that all contraccts can be perfectly and costlessly enforced. Some of the "transaction cost" literature has started to move beyond this assumption, but there are few compelling results or consensus theories in the area of techniques and costs of contract enforcement. 
+    A aplicação desse tipo de análise à fase de desempenho dos contratos é menos direta. Para começar, as teorias econômicas da fase de desempenho não são tão bem desenvolvidas ou simples quanto a teoria do mecanismo das negociações. De fato, a maior parte da teoria econômica simplesmente assume que todos os contracctos podem ser perfeitamente e sem custos impostos. Parte da literatura sobre "custos de transação" começou a ir além dessa hipótese, mas há poucos resultados convincentes ou teorias de consenso na área de técnicas e custos de execução de contratos.
   </p>
 
   <p>
-    Performance phase analysis with multiparty secure computer theory would seem to apply only to those contracts which can be performed inside the virtual computer. But the use of post-unforgeable auditing logs, combined with running auditing protocols inside the shared virtual computer, allows a wide variety of performances outside the virtual computer to at least be observed and verified by selected arbitrators, albeit not proactively self-enforced. 
+    A análise da fase de desempenho com a teoria de computador segura multipartidária parece se aplicar apenas aos contratos que podem ser executados dentro do computador virtual. Mas o uso de registros de auditoria pós-inutilizáveis, combinado com a execução de protocolos de auditoria dentro do computador virtual compartilhado, permite que uma ampla variedade de performances fora do computador virtual seja pelo menos observada e verificada por arbitradores selecionados, embora não seja auto-aplicada de forma proativa.
   </p>
 
   <p>
-    The participants in this mutually <a href="http://szabo.best.vwh.net/confidential.html">confidential auditing</a> protocol can verify that the books match the details of transactions stored in a previously committed transaction log, and that the numbers add up correctly. The participants can compute summary statistics on their confidentially shared transaction logs, including cross-checking of the logs against counterparties to a transaction, without revealing those logs. They only learn what can be inferred from the statistics, can't see the details of the transactions. Another intriguing possibility is that the virtual computer can keep state over long periods of time, allowing sophisticated forms of privy and self-enforcing <a href="http://szabo.best.vwh.net/garnishment.html">secured credit.</a>
+    Os participantes desse protocolo de <a href="http://szabo.best.vwh.net/confidential.html">auditoria mutualmente confidencial</a> podem verificar se os livros correspondem aos detalhes das transações armazenadas em um log de transações previamente confirmado e se os números se somam corretamente. Os participantes podem calcular estatísticas resumidas em seus registros de transação compartilhados confidencialmente, incluindo a verificação cruzada dos registros em relação a contrapartes em uma transação, sem revelar esses registros. Eles só aprendem o que pode ser inferido das estatísticas, não podem ver os detalhes das transações. Outra possibilidade intrigante é que o computador virtual possa manter o estado por longos períodos de tempo, permitindo formas sofisticadas de <a href="http://szabo.best.vwh.net/garnishment.html">crédito seguro</a> e auto-imposto.
   </p>
 
   <p>
-    If mutually confidential auditing ever becomes practical, we will be able to gain high confidence in the factuality of counterparties' claims and reports without revealing identifying and other detailed information from the transactions underlying those reports. These would provide the basis for solid <a href="http://szabo.best.vwh.net/negative_rep.html">reputation systems</a>, and other trusted third party systems, that maintain integrity across time, communications, summarization, and preserve confidentiality for transaction participants. Knowing that mutually confidential auditing can be accomplished in principle will hopefully lead us to practical solutions to these important
-    problems.
+    Se a auditoria mutuamente confidencial se tornar prática, poderemos obter alta confiança na factualidade das declarações e relatórios das contrapartes, sem revelar informações de identificação e outras informações detalhadas das transações subjacentes a esses relatórios. Isso forneceria a base para sólidos <a href="http://szabo.best.vwh.net/negative_rep.html">sistemas de reputação</a>, e outros sistemas confiáveis ​​de terceiros, que mantêm a integridade ao longo do tempo, as comunicações, a sumarização e preservam a confidencialidade dos participantes da transação. Sabendo que a auditoria mutuamente confidencial pode ser realizada em princípio, esperamos que nos leve a soluções práticas para esses problemas importantes.
   </p>
 
-  <h2>References</h2>
+  <h2>Referências</h2>
 
   <ol>
     <li id="fn1">
       <p>
-        D. Chaum, C. Cr&eacute;peau, and I. Damgaard, Multiparty unconditionally secure protocols; In 19th Symp. on Theory of Computing, pages 11-19. ACM, 1988.
+        D. Chaum, C. Cr&eacute;peau, and I. Damgaard, Multiparty unconditionally secure protocols; In 19th Symp. on Theory of Computing, páginas 11-19. ACM, 1988.
       </p>
     </li>
 
     <li id="fn2">
       <p>
-        "The Spymasters Double Agent Problem: Multiparty Computations Secure Unconditionally from Minorities and Cryptographically from Majorities," D. Chaum, Advances in Cryptology CRYPTO'89, G. Brassard (Ed.), Springer-Verlag, pp. 591-601.
+        "The Spymasters Double Agent Problem: Multiparty Computations Secure Unconditionally from Minorities and Cryptographically from Majorities," D. Chaum, Advances in Cryptology CRYPTO'89, G. Brassard (Ed.), Springer-Verlag, páginas. 591-601.
       </p>
     </li>
 
@@ -120,19 +118,19 @@
 
     <li id="fn6">
       <p>
-        R. Cramer, I. Damgaard, S. Dziembowski, M. Hirt, T. Rabin, Efficient Multi-Party Computations with Dishonest Majority, Proceedings of Eurocrypt '99, Springer Verlag LNCS, to appear (May '99).&nbsp;<a href="#ref6">↩</a>
+        R. Cramer, I. Damgaard, S. Dziembowski, M. Hirt, T. Rabin, Efficient Multi-Party Computations with Dishonest Majority, Proceedings of Eurocrypt '99, Springer Verlag LNCS, to appear (Maio de 1999).&nbsp;<a href="#ref6">↩</a>
       </p>
     </li>
   </ol>
 
   <hr>
   <p>
-    Please send your comments to nszabo (at) law (dot) gwu (dot) edu
+    Por favor envie seus comentários para nszabo@law.gwu.edu
   </p>
 
   <p>
-    Copyright &copy; 1997-1999 by Nick Szabo<br>
-    Permission to redistribute without alteration hereby granted
+    Direito Autoral &copy; 1997-1999 por Nick Szabo<br>
+    Permissão para redistribuir sem alteração previamente concedida.
   </p>
 
 </div>


### PR DESCRIPTION
Tradução de:
Detectando gastos duplicados
Remailers para pagar
Reputação negativa
Verificações de dinheiro online
Equívocos de confiança no PGP Web
O direito de ler
Os protocolos de Deus

Observação:
[1] links e mídias quebradas foram ignoradas e copiadas exatamente como estão no arquivo original.
[2] Reestruturação do artigo "Remailers para pagar", adicionado quebra de linhas entre parágrafos.