### PR TITLE
fix: Remove espaços extras na viewport meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,16 +1,15 @@
 <meta charset="utf-8"> {% include seo.html %}
 
-
 <!-- https://t.co/dKP3o1e -->
-<meta name=" viewport " content=" width=device-width, initial-scale=1.0 ">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
 
 <script>
     document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
 <!-- For all browsers -->
-<link rel=" stylesheet " href=" {{ '/assets/css/main.css' | relative_url }} ">
-<link rel=" stylesheet " href=" https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css ">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css">
 
 <!--[if IE]>
   <style>
@@ -28,5 +27,5 @@
 <![endif]-->
 
 {% if site.head_scripts %} {% for script in site.head_scripts %}
-<script src=" {{ script | relative_url }} "></script>
+<script src="{{ script | relative_url }}"></script>
 {% endfor %} {% endif %}


### PR DESCRIPTION
Há espaços adicionais ao redor de alguns atributos em _includes/head.html. Removi todos que encontrei mas, os espaços adicionais na viewport meta tag estavam comprometendo a responsividade. Além disso, adicionei `"shrink-to-fit=no"` por causa [disso](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html#//apple_ref/doc/uid/TP40014305-CH10-SW6). Valeu rapaziada espero ter ajudado :call_me_hand: 